### PR TITLE
Add usesFirefoxSync to target users already signed in

### DIFF
--- a/whats-new-panel.json
+++ b/whats-new-panel.json
@@ -19,7 +19,7 @@
     "frequency": {
       "lifetime": 100
     },
-    "targeting": "firefoxVersion == 72 && (hasAccessedFxAPanel || currentDate|date - 2419200000 >= profileAgeCreated) && (!messageImpressions['WHATS_NEW_BADGE_72'] || (messageImpressions['WHATS_NEW_BADGE_72']|length >= 1 && currentDate|date - messageImpressions['WHATS_NEW_BADGE_72'][0] <= 345600000)) && 'browser.messaging-system.whatsNewPanel.enabled'|preferenceValue",
+    "targeting": "firefoxVersion == 72 && (usesFirefoxSync || hasAccessedFxAPanel || currentDate|date - 2419200000 >= profileAgeCreated) && (!messageImpressions['WHATS_NEW_BADGE_72'] || (messageImpressions['WHATS_NEW_BADGE_72']|length >= 1 && currentDate|date - messageImpressions['WHATS_NEW_BADGE_72'][0] <= 345600000)) && 'browser.messaging-system.whatsNewPanel.enabled'|preferenceValue",
     "id": "WHATS_NEW_BADGE_72"
   },
   {


### PR DESCRIPTION
I realized there was a case the targeting expression was missing.
* profiles > 28 days get the wnp badge
* profiles that interacted with the FxA btn get the badge
* if you sign in to FxA through the Applications menu you invalidate the `FXA_BADGE` targeting, the FxA button is no longer badged but it doesn't active the wnp badge
  * `usesFirefoxSync` is `true` but `hasAccessedFxAPanel` is `false` and if your profile is < 28 days you are left without a notification

For reference the FxA btn badge targeting:
```
isFxABadgeEnabled && !hasAccessedFxAPanel &&
!usesFirefoxSync && isFxAEnabled == true
```