### PR TITLE
Add Import Password CFR

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -1860,7 +1860,7 @@
     "frequency": {
       "lifetime": 3
     },
-    "targeting": "firefoxVersion >= 73 && locale = \"en-US\" && ((currentDate|date - profileAgeCreated) / 86400000) < 7 && userPrefs.cfrFeatures && 'browser.newtabpage.activity-stream.asrouter.providers.cfr'|preferenceValue == '{\"id\":\"cfr\",\"enabled\":true,\"type\":\"remote-settings\",\"bucket\":\"cfr\",\"frequency\":{\"custom\":[{\"period\":\"daily\",\"cap\":1}]},\"categories\":[\"cfrAddons\",\"cfrFeatures\"],\"updateCycleInMs\":3600000,\"cohort\":\"import_password_treatment\"}'",
+    "targeting": "firefoxVersion >= 73 && locale == \"en-US\" && ((currentDate|date - profileAgeCreated) / 86400000) < 7 && userPrefs.cfrFeatures && 'browser.newtabpage.activity-stream.asrouter.providers.cfr'|preferenceValue == '{\"id\":\"cfr\",\"enabled\":true,\"type\":\"remote-settings\",\"bucket\":\"cfr\",\"frequency\":{\"custom\":[{\"period\":\"daily\",\"cap\":1}]},\"categories\":[\"cfrAddons\",\"cfrFeatures\"],\"updateCycleInMs\":3600000,\"cohort\":\"import_password_treatment\"}'",
     "template": "cfr_doorhanger",
     "trigger": {
       "id": "openURL",

--- a/cfr.json
+++ b/cfr.json
@@ -1795,5 +1795,97 @@
         2048
       ]
     }
+  },
+  {
+    "id": "IMPORT_PASSWORD",
+    "content": {
+      "bucket_id": "CFR_IMPORT_PASSWORD",
+      "buttons": {
+        "primary": {
+          "action": {
+            "data": {
+              "category": "sync"
+            },
+            "type": "SHOW_MIGRATION_WIZARD"
+          },
+          "label": {
+            "attributes": {
+              "accesskey": "s"
+            },
+            "value": "Import Passwords"
+          }
+        },
+        "secondary": [
+          {
+            "action": {
+              "type": "CANCEL"
+            },
+            "label": {
+              "string_id": "cfr-doorhanger-extension-cancel-button"
+            }
+          },
+          {
+            "label": {
+              "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+            }
+          },
+          {
+            "action": {
+              "data": {
+                "category": "general-cfrfeatures"
+              },
+              "type": "OPEN_PREFERENCES_PAGE"
+            },
+            "label": {
+              "string_id": "cfr-doorhanger-extension-manage-settings-button"
+            }
+          }
+        ]
+      },
+      "category": "cfrFeatures",
+      "heading_text": "Import Your Password From Other Browsers",
+      "icon": "chrome://browser/content/aboutlogins/icons/intro-illustration.svg",
+      "info_icon": {
+        "label": {
+          "string_id": "cfr-doorhanger-extension-sumo-link"
+        },
+        "sumo_path": "extensionrecommendations"
+      },
+      "layout": "icon_and_message",
+      "notification_text": {
+        "string_id": "cfr-doorhanger-feature-notification"
+      },
+      "text": "You can import your passwords and settings from Google Chrome or Edge.  Would you like to import those settings?"
+    },
+    "frequency": {
+      "lifetime": 3
+    },
+    "targeting": "firefoxVersion >= 73 && locale = \"en-US\" && ((currentDate|date - profileAgeCreated) / 86400000) < 7 && userPrefs.cfrFeatures && 'browser.newtabpage.activity-stream.asrouter.providers.cfr'|preferenceValue == '{\"id\":\"cfr\",\"enabled\":true,\"type\":\"remote-settings\",\"bucket\":\"cfr\",\"frequency\":{\"custom\":[{\"period\":\"daily\",\"cap\":1}]},\"categories\":[\"cfrAddons\",\"cfrFeatures\"],\"updateCycleInMs\":3600000,\"cohort\":\"import_password_treatment\"}'",
+    "template": "cfr_doorhanger",
+    "trigger": {
+      "id": "openURL",
+      "params": [
+        "docs.google.com",
+        "www.docs.google.com",
+        "calendar.google.com",
+        "mail.google.com",
+        "outlook.live.com",
+        "facebook.com",
+        "www.facebook.com",
+        "twitter.com",
+        "www.twitter.com",
+        "reddit.com",
+        "www.reddit.com",
+        "github.com",
+        "www.github.com",
+        "youtube.com",
+        "www.youtube.com",
+        "feedly.com",
+        "www.feedly.com",
+        "drive.google.com",
+        "netflix.com",
+        "www.netflix.com"
+      ]
+    }
   }
 ]

--- a/cfr.json
+++ b/cfr.json
@@ -1797,7 +1797,7 @@
     }
   },
   {
-    "id": "IMPORT_PASSWORD",
+    "id": "CFR_EXP_IMPORT_PASSWORD",
     "content": {
       "bucket_id": "CFR_IMPORT_PASSWORD",
       "buttons": {
@@ -1866,7 +1866,6 @@
       "id": "openURL",
       "params": [
         "docs.google.com",
-        "www.docs.google.com",
         "calendar.google.com",
         "mail.google.com",
         "outlook.live.com",

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -1375,7 +1375,7 @@
       you like to import those settings?
   frequency:
     lifetime: 3
-  targeting: firefoxVersion >= 73 && locale = "en-US" && ((currentDate|date - profileAgeCreated) / 86400000) < 7 && userPrefs.cfrFeatures && 'browser.newtabpage.activity-stream.asrouter.providers.cfr'|preferenceValue == '{"id":"cfr","enabled":true,"type":"remote-settings","bucket":"cfr","frequency":{"custom":[{"period":"daily","cap":1}]},"categories":["cfrAddons","cfrFeatures"],"updateCycleInMs":3600000,"cohort":"import_password_treatment"}'
+  targeting: firefoxVersion >= 73 && locale == "en-US" && ((currentDate|date - profileAgeCreated) / 86400000) < 7 && userPrefs.cfrFeatures && 'browser.newtabpage.activity-stream.asrouter.providers.cfr'|preferenceValue == '{"id":"cfr","enabled":true,"type":"remote-settings","bucket":"cfr","frequency":{"custom":[{"period":"daily","cap":1}]},"categories":["cfrAddons","cfrFeatures"],"updateCycleInMs":3600000,"cohort":"import_password_treatment"}'
   template: cfr_doorhanger
   trigger:
     id: openURL

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -1335,7 +1335,7 @@
     id: contentBlocking
     params:
     - 2048
-- id: IMPORT_PASSWORD
+- id: CFR_EXP_IMPORT_PASSWORD
   content:
     bucket_id: CFR_IMPORT_PASSWORD
     buttons:
@@ -1381,7 +1381,6 @@
     id: openURL
     params:
     - docs.google.com
-    - www.docs.google.com
     - calendar.google.com
     - mail.google.com
     - outlook.live.com

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -1335,3 +1335,68 @@
     id: contentBlocking
     params:
     - 2048
+- id: IMPORT_PASSWORD
+  content:
+    bucket_id: CFR_IMPORT_PASSWORD
+    buttons:
+      primary:
+        action:
+          data:
+            category: sync
+          type: SHOW_MIGRATION_WIZARD
+        label:
+          attributes:
+            accesskey: s
+          value: Import Passwords
+      secondary:
+      - action:
+          type: CANCEL
+        label:
+          string_id: cfr-doorhanger-extension-cancel-button
+      - label:
+          string_id: cfr-doorhanger-extension-never-show-recommendation
+      - action:
+          data:
+            category: general-cfrfeatures
+          type: OPEN_PREFERENCES_PAGE
+        label:
+          string_id: cfr-doorhanger-extension-manage-settings-button
+    category: cfrFeatures
+    heading_text: Import Your Password From Other Browsers
+    icon: chrome://browser/content/aboutlogins/icons/intro-illustration.svg
+    info_icon:
+      label:
+        string_id: cfr-doorhanger-extension-sumo-link
+      sumo_path: extensionrecommendations
+    layout: icon_and_message
+    notification_text:
+      string_id: cfr-doorhanger-feature-notification
+    text: You can import your passwords and settings from Google Chrome or Edge.  Would
+      you like to import those settings?
+  frequency:
+    lifetime: 3
+  targeting: firefoxVersion >= 73 && locale = "en-US" && ((currentDate|date - profileAgeCreated) / 86400000) < 7 && userPrefs.cfrFeatures && 'browser.newtabpage.activity-stream.asrouter.providers.cfr'|preferenceValue == '{"id":"cfr","enabled":true,"type":"remote-settings","bucket":"cfr","frequency":{"custom":[{"period":"daily","cap":1}]},"categories":["cfrAddons","cfrFeatures"],"updateCycleInMs":3600000,"cohort":"import_password_treatment"}'
+  template: cfr_doorhanger
+  trigger:
+    id: openURL
+    params:
+    - docs.google.com
+    - www.docs.google.com
+    - calendar.google.com
+    - mail.google.com
+    - outlook.live.com
+    - facebook.com
+    - www.facebook.com
+    - twitter.com
+    - www.twitter.com
+    - reddit.com
+    - www.reddit.com
+    - github.com
+    - www.github.com
+    - youtube.com
+    - www.youtube.com
+    - feedly.com
+    - www.feedly.com
+    - drive.google.com
+    - netflix.com
+    - www.netflix.com


### PR DESCRIPTION
This implements [bug 1617648](https://bugzilla.mozilla.org/show_bug.cgi?id=1617648).

Targeting highlights:
* locale: en-US
* profile age: < 7 days
* experiment cohort: the CFR pref set by Normandy with a `"cohort": "import_password_treatment"`

Note that this experiment would target those users with `userAttribution.us in ["chrome", "edge"]`, and it will rely on Normandy to enforce that, so we don't have such targeting in the CFR targeting string.