### PR TITLE
Bug 1618281 - Deploy badge icon for 74

### DIFF
--- a/whats-new-panel.json
+++ b/whats-new-panel.json
@@ -351,5 +351,28 @@
     "trigger": {
       "id": "whatsNewPanelOpened"
     }
+  },
+  {
+    "id": "WHATS_NEW_BADGE_74",
+    "content": {
+      "action": {
+        "id": "show-whatsnew-button"
+      },
+      "badgeDescription": {
+        "string_id": "cfr-badge-reader-label-newfeature"
+      },
+      "bucket_id": "WHATS_NEW_BADGE_74",
+      "delay": 300000,
+      "target": "whats-new-menu-button"
+    },
+    "frequency": {
+      "lifetime": 100
+    },
+    "priority": 5,
+    "targeting": "firefoxVersion == 74 && (usesFirefoxSync || hasAccessedFxAPanel || currentDate|date - 2419200000 >= profileAgeCreated) && (!messageImpressions['WHATS_NEW_BADGE_74'] || (messageImpressions['WHATS_NEW_BADGE_74']|length >= 1 && currentDate|date - messageImpressions['WHATS_NEW_BADGE_74'][0] <= 345600000)) && 'browser.messaging-system.whatsNewPanel.enabled'|preferenceValue",
+    "template": "toolbar_badge",
+    "trigger": {
+      "id": "toolbarBadgeUpdate"
+    }
   }
 ]

--- a/whats-new-panel.yaml
+++ b/whats-new-panel.yaml
@@ -277,3 +277,22 @@
   targeting: firefoxVersion >= 74
   trigger:
     id: whatsNewPanelOpened
+- id: WHATS_NEW_BADGE_74
+  content:
+    action:
+      id: show-whatsnew-button
+    badgeDescription:
+      string_id: cfr-badge-reader-label-newfeature
+    bucket_id: WHATS_NEW_BADGE_74
+    delay: 300000
+    target: whats-new-menu-button
+  frequency:
+    lifetime: 100
+  priority: 5
+  targeting: firefoxVersion == 74 && (usesFirefoxSync || hasAccessedFxAPanel || currentDate|date
+    - 2419200000 >= profileAgeCreated) && (!messageImpressions['WHATS_NEW_BADGE_74']
+    || (messageImpressions['WHATS_NEW_BADGE_74']|length >= 1 && currentDate|date -
+    messageImpressions['WHATS_NEW_BADGE_74'][0] <= 345600000)) && 'browser.messaging-system.whatsNewPanel.enabled'|preferenceValue
+  template: toolbar_badge
+  trigger:
+    id: toolbarBadgeUpdate


### PR DESCRIPTION
As part of the deploy I will also remove `WHATS_NEW_PERMISSION_PROMPT_72` to keep a limit of 3 messages in the toolbar dropdown.

[A breakdown of the targeting expression](https://bugzilla.mozilla.org/show_bug.cgi?id=1597708#c5)