### PR TITLE
Add bucket_id for FXA_BOOKMARK_PANEL_71_plus

### DIFF
--- a/cfr-fxa.json
+++ b/cfr-fxa.json
@@ -4,6 +4,7 @@
     "content": {
       "background_color_1": "#7d31ae",
       "background_color_2": "#5033be",
+      "bucket_id": "FXA_BOOKMARK_PANEL_71_plus",
       "close_button": {
         "tooltiptext": {
           "string_id": "cfr-doorhanger-bookmark-fxa-close-btn-tooltip"

--- a/cfr-fxa.yaml
+++ b/cfr-fxa.yaml
@@ -2,6 +2,7 @@
   content:
     background_color_1: '#7d31ae'
     background_color_2: '#5033be'
+    bucket_id: FXA_BOOKMARK_PANEL_71_plus
     close_button:
       tooltiptext:
         string_id: cfr-doorhanger-bookmark-fxa-close-btn-tooltip


### PR DESCRIPTION
Noticed this while making dashboard for FxA Bookmark Panel.

Without the `bucket_id`, we won't be able to identify those messages in `cfr-fxa` in the release channel. 