### PR TITLE
Add schema validation for JSON assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,3 @@ check:
 	scripts/validate.py cfr.json schema/cfr.schema.json
 	scripts/validate.py cfr-fxa.json schema/cfr-fxa.schema.json
 	scripts/validate.py whats-new-panel.json schema/whats-new-panel.schema.json
-

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,13 @@ all: cfr.json cfr-archived.json cfr-fxa.json cfr-fxa-archived.json whats-new-pan
 pre-build:
 	yamllint .
 
-.PHONY: clean
+.PHONY: clean check
 
 clean:
 	rm *.json
+
+check:
+	scripts/validate.py cfr.json schema/cfr.schema.json
+	scripts/validate.py cfr-fxa.json schema/cfr-fxa.schema.json
+	scripts/validate.py whats-new-panel.json schema/whats-new-panel.schema.json
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ To sync from YAML to JSON, just run
 $ make
 ```
 
+To validate the JSON against the schema
+
+```sh
+$ make check
+```
+
 It requires Python 3 and pyyaml for the conversion.
 
 ```sh
@@ -19,6 +25,9 @@ It requires Python 3 and pyyaml for the conversion.
 $ brew install python3
 $ pip3 install pyyaml
 $ pip3 install yamllint
+
+# this is for schema validation
+$ pip3 install jsonschema
 ```
 
 Note: make sure you commit all the changes (YAML&JSON) to the repo.

--- a/schema/cfr-fxa.schema.json
+++ b/schema/cfr-fxa.schema.json
@@ -1,0 +1,414 @@
+{
+  "title": "ExtensionDoorhanger",
+  "description": "A template with a heading, addon icon, title and description. No markup allowed.",
+  "version": "1.0.0",
+  "type": "object",
+  "definitions": {
+    "plainText": {
+      "description": "Plain text (no HTML allowed)",
+      "type": "string"
+    },
+    "linkUrl": {
+      "description": "Target for links or buttons",
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Message identifier"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "layout": {
+          "type": "string",
+          "description": "Attribute used for different groups of messages from the same provider",
+          "enum": ["short_message", "message_and_animation", "icon_and_message", "addon_recommendation"]
+        },
+        "anchor_id": {
+          "type": "string",
+          "description": "A DOM element ID that the pop-over will be anchored."
+        },
+        "bucket_id": {
+          "type": "string",
+          "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+        },
+        "skip_address_bar_notifier": {
+          "type": "boolean",
+          "description": "Skip the 'Recommend' notifier and show directly."
+        },
+        "notification_text": {
+          "description": "The text in the small blue chicklet that appears in the URL bar. This can be a reference to a localized string in Firefox or just a plain string.",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Message shown in the location bar notification."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "string_id": {
+                  "type": "string",
+                  "description": "Id of localized string for the location bar notification."
+                }
+              },
+              "required": ["string_id"]
+            }
+          ]
+        },
+        "info_icon": {
+          "type": "object",
+          "description": "The small icon displayed in the top right corner of the pop-over. Should be 19x19px, svg or png. Defaults to a small question mark." ,
+          "properties": {
+            "label": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "attributes": {
+                      "type": "object",
+                      "properties": {
+                        "tooltiptext": {
+                          "type": "string",
+                          "description": "Text for button tooltip used to provide information about the doorhanger."
+                        }
+                      },
+                      "required": ["tooltiptext"]
+                    }
+                  },
+                  "required": ["attributes"]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "string_id": {
+                      "type": "string",
+                      "description": "Id of localized string used to provide information about the doorhanger."
+                    }
+                  },
+                  "required": ["string_id"]
+                }
+              ]
+            },
+            "sumo_path": {
+              "type": "string",
+              "description": "Last part of the path in the URL to the support page with the information about the doorhanger.",
+              "examples": ["extensionpromotions", "extensionrecommendations"]
+            }
+          }
+        },
+        "learn_more": {
+          "type": "string",
+          "description": "Last part of the path in the SUMO URL to the support page with the information about the doorhanger.",
+          "examples": ["extensionpromotions", "extensionrecommendations"]
+        },
+        "heading_text": {
+          "description": "The larger heading text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string.",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "The message displayed in the title of the extension doorhanger"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "string_id": {
+                  "type": "string"
+                }
+              },
+              "required": ["string_id"],
+              "description": "Id of localized string for extension doorhanger title"
+            }
+          ]
+        },
+        "icon": {
+          "description": "The icon displayed in the pop-over. Should be 32x32px or 64x64px and png/svg.",
+          "allOf": [
+            {"$ref": "#/definitions/linkUrl"},
+            {"description": "Icon associated with the message"}
+          ]
+        },
+        "icon_dark_theme": {
+          "type": "string",
+          "description": "Pop-over icon, dark theme variant. Should be 32x32px or 64x64px and png/svg."
+        },
+        "icon_class": {
+          "type": "string",
+          "description": "CSS class of the pop-over icon."
+        },
+        "addon": {
+          "description": "Addon information including AMO URL.",
+          "type": "object",
+          "properties": {
+            "id": {
+              "allOf": [
+                {"$ref": "#/definitions/plainText"},
+                {"description": "Unique addon ID"}
+              ]
+            },
+            "title": {
+              "allOf": [
+                {"$ref": "#/definitions/plainText"},
+                {"description": "Addon name"}
+              ]
+            },
+            "author": {
+              "allOf": [
+                {"$ref": "#/definitions/plainText"},
+                {"description": "Addon author"}
+              ]
+            },
+            "icon": {
+              "description": "The icon displayed in the pop-over. Should be 64x64px and png/svg.",
+              "allOf": [
+                {"$ref": "#/definitions/linkUrl"},
+                {"description": "Addon icon"}
+              ]
+            },
+            "rating": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 5,
+              "description": "Star rating"
+            },
+            "users": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Installed users"
+            },
+            "amo_url": {
+              "allOf": [
+                {"$ref": "#/definitions/linkUrl"},
+                {"description": "Link that offers more information related to the addon."}
+              ]
+            }
+          },
+          "required": ["title", "author", "icon", "amo_url"]
+        },
+        "text": {
+          "description": "The body text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string.",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Description message of the addon."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "string_id": {
+                  "type": "string",
+                  "description": "Id of string to localized addon description"
+                }
+              },
+              "required": ["string_id"]
+            }
+          ]
+        },
+        "descriptionDetails": {
+          "description": "Additional information and steps on how to use",
+          "type": "object",
+          "properties": {
+            "steps": {
+              "description": "Array of messages or string_ids",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "string_id": {
+                    "type": "string",
+                    "description": "Id of string to localized addon description"
+                  }
+                },
+                "required": ["string_id"]
+              }
+            }
+          },
+          "required": ["steps"]
+        },
+        "buttons": {
+          "description": "The label and functionality for the buttons in the pop-over.",
+          "type": "object",
+          "properties": {
+            "primary": {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "object",
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "value": {
+                          "allOf": [
+                            {"$ref": "#/definitions/plainText"},
+                            {"description": "Button label override used when a localized version is not available."}
+                          ]
+                        },
+                        "attributes": {
+                          "type": "object",
+                          "properties": {
+                            "accesskey": {
+                              "type": "string",
+                              "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                            }
+                          },
+                          "required": ["accesskey"],
+                          "description": "Button attributes."
+                        }
+                      },
+                      "required": ["value", "attributes"]
+                    },
+                    {
+                      "properties": {
+                        "string_id": {
+                          "allOf": [
+                            {"$ref": "#/definitions/plainText"},
+                            {"description": "Id of localized string for button"}
+                          ]
+                        }
+                      },
+                      "required": ["string_id"]
+                    }
+                  ],
+                  "description": "Id of localized string or message override."
+                },
+                "action": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "Action dispatched by the button."
+                    },
+                    "data": {
+                      "properties": {
+                        "url": {
+                          "type": "null",
+                          "$comment": "This is dynamically generated from the addon.id. See CFRPageActions.jsm",
+                          "description": "URL used in combination with the primary action dispatched."
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "secondary": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "object",
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "allOf": [
+                              {"$ref": "#/definitions/plainText"},
+                              {"description": "Button label override used when a localized version is not available."}
+                            ]
+                          },
+                          "attributes": {
+                            "type": "object",
+                            "properties": {
+                              "accesskey": {
+                                "type": "string",
+                                "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                              }
+                            },
+                            "required": ["accesskey"],
+                            "description": "Button attributes."
+                          }
+                        },
+                        "required": ["value", "attributes"]
+                      },
+                      {
+                        "properties": {
+                          "string_id": {
+                            "allOf": [
+                              {"$ref": "#/definitions/plainText"},
+                              {"description": "Id of localized string for button"}
+                            ]
+                          }
+                        },
+                        "required": ["string_id"]
+                      }
+                    ],
+                    "description": "Id of localized string or message override."
+                  },
+                  "action": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "Action dispatched by the button."
+                      },
+                      "data": {
+                        "properties": {
+                          "url": {
+                            "allOf": [
+                              {"$ref": "#/definitions/linkUrl"},
+                              {"description": "URL used in combination with the primary action dispatched."}
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": true,
+      "required": ["bucket_id"]
+    },
+    "frequency": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "lifetime": {
+          "type": "integer"
+        },
+        "custom": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "cap": {
+                "type": "integer"
+              },
+              "period": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "priority": {
+      "type": "integer"
+    },
+    "targeting": {
+      "type": "string"
+    },
+    "template": {
+      "type": "string"
+    },
+    "trigger": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "params": {
+          "type": "array"
+        }
+      },
+      "required": ["id"]
+    },
+    "weight": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["id", "content", "targeting", "template", "trigger"]
+}

--- a/schema/cfr-fxa.schema.json
+++ b/schema/cfr-fxa.schema.json
@@ -364,22 +364,43 @@
     },
     "frequency": {
       "type": "object",
-      "additionalProperties": false,
+      "description": "An object containing frequency cap information for a message.",
       "properties": {
         "lifetime": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The maximum lifetime impressions for a message.",
+          "minimum": 1,
+          "maximum": 100
         },
         "custom": {
           "type": "array",
+          "description": "An array of custom frequency cap definitions.",
           "items": {
+            "description": "A frequency cap definition containing time and max impression information",
+            "type": "object",
             "properties": {
-              "cap": {
-                "type": "integer"
-              },
               "period": {
-                "type": "integer"
+                "oneOf": [
+                  {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  {
+                    "type": "string",
+                    "description": "One of a preset list of short forms for period of time (e.g. 'daily' for one day)",
+                    "enum": ["daily"]
+                  }
+                ]
+
+              },
+              "cap": {
+                "type": "integer",
+                "description": "The maximum impressions for the message within the defined period.",
+                "minimum": 1,
+                "maximum": 100
               }
-            }
+            },
+            "required": ["period", "cap"]
           }
         }
       }
@@ -388,19 +409,29 @@
       "type": "integer"
     },
     "targeting": {
-      "type": "string"
+      "type": "string",
+      "description": "A JEXL expression representing targeting information"
     },
     "template": {
       "type": "string"
     },
     "trigger": {
       "type": "object",
+      "description": "An action to trigger potentially showing the message",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "A string identifying the trigger action"
         },
         "params": {
-          "type": "array"
+          "type": "array",
+          "description": "An optional array of string parameters for the trigger action",
+          "items": {
+            "anyOf": [
+              { "type": "integer" },
+              { "type": "string" }
+            ]
+          }
         }
       },
       "required": ["id"]

--- a/schema/cfr.schema.json
+++ b/schema/cfr.schema.json
@@ -368,22 +368,43 @@
     },
     "frequency": {
       "type": "object",
-      "additionalProperties": false,
+      "description": "An object containing frequency cap information for a message.",
       "properties": {
         "lifetime": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The maximum lifetime impressions for a message.",
+          "minimum": 1,
+          "maximum": 100
         },
         "custom": {
           "type": "array",
+          "description": "An array of custom frequency cap definitions.",
           "items": {
+            "description": "A frequency cap definition containing time and max impression information",
+            "type": "object",
             "properties": {
-              "cap": {
-                "type": "integer"
-              },
               "period": {
-                "type": "integer"
+                "oneOf": [
+                  {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  {
+                    "type": "string",
+                    "description": "One of a preset list of short forms for period of time (e.g. 'daily' for one day)",
+                    "enum": ["daily"]
+                  }
+                ]
+
+              },
+              "cap": {
+                "type": "integer",
+                "description": "The maximum impressions for the message within the defined period.",
+                "minimum": 1,
+                "maximum": 100
               }
-            }
+            },
+            "required": ["period", "cap"]
           }
         }
       }
@@ -392,19 +413,29 @@
       "type": "integer"
     },
     "targeting": {
-      "type": "string"
+      "type": "string",
+      "description": "A JEXL expression representing targeting information"
     },
     "template": {
       "type": "string"
     },
     "trigger": {
       "type": "object",
+      "description": "An action to trigger potentially showing the message",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "A string identifying the trigger action"
         },
         "params": {
-          "type": "array"
+          "type": "array",
+          "description": "An optional array of string parameters for the trigger action",
+          "items": {
+            "anyOf": [
+              { "type": "integer" },
+              { "type": "string" }
+            ]
+          }
         }
       },
       "required": ["id"]

--- a/schema/cfr.schema.json
+++ b/schema/cfr.schema.json
@@ -1,0 +1,418 @@
+{
+  "title": "ExtensionDoorhanger",
+  "description": "A template with a heading, addon icon, title and description. No markup allowed.",
+  "version": "1.0.0",
+  "type": "object",
+  "definitions": {
+    "plainText": {
+      "description": "Plain text (no HTML allowed)",
+      "type": "string"
+    },
+    "linkUrl": {
+      "description": "Target for links or buttons",
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Message identifier"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "Attribute used for different groups of messages from the same provider"
+        },
+        "layout": {
+          "type": "string",
+          "description": "Attribute used for different groups of messages from the same provider",
+          "enum": ["short_message", "message_and_animation", "icon_and_message", "addon_recommendation"]
+        },
+        "anchor_id": {
+          "type": "string",
+          "description": "A DOM element ID that the pop-over will be anchored."
+        },
+        "bucket_id": {
+          "type": "string",
+          "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+        },
+        "skip_address_bar_notifier": {
+          "type": "boolean",
+          "description": "Skip the 'Recommend' notifier and show directly."
+        },
+        "notification_text": {
+          "description": "The text in the small blue chicklet that appears in the URL bar. This can be a reference to a localized string in Firefox or just a plain string.",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Message shown in the location bar notification."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "string_id": {
+                  "type": "string",
+                  "description": "Id of localized string for the location bar notification."
+                }
+              },
+              "required": ["string_id"]
+            }
+          ]
+        },
+        "info_icon": {
+          "type": "object",
+          "description": "The small icon displayed in the top right corner of the pop-over. Should be 19x19px, svg or png. Defaults to a small question mark." ,
+          "properties": {
+            "label": {
+              "oneOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "attributes": {
+                      "type": "object",
+                      "properties": {
+                        "tooltiptext": {
+                          "type": "string",
+                          "description": "Text for button tooltip used to provide information about the doorhanger."
+                        }
+                      },
+                      "required": ["tooltiptext"]
+                    }
+                  },
+                  "required": ["attributes"]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "string_id": {
+                      "type": "string",
+                      "description": "Id of localized string used to provide information about the doorhanger."
+                    }
+                  },
+                  "required": ["string_id"]
+                }
+              ]
+            },
+            "sumo_path": {
+              "type": "string",
+              "description": "Last part of the path in the URL to the support page with the information about the doorhanger.",
+              "examples": ["extensionpromotions", "extensionrecommendations"]
+            }
+          }
+        },
+        "learn_more": {
+          "type": "string",
+          "description": "Last part of the path in the SUMO URL to the support page with the information about the doorhanger.",
+          "examples": ["extensionpromotions", "extensionrecommendations"]
+        },
+        "heading_text": {
+          "description": "The larger heading text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string.",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "The message displayed in the title of the extension doorhanger"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "string_id": {
+                  "type": "string"
+                }
+              },
+              "required": ["string_id"],
+              "description": "Id of localized string for extension doorhanger title"
+            }
+          ]
+        },
+        "icon": {
+          "description": "The icon displayed in the pop-over. Should be 32x32px or 64x64px and png/svg.",
+          "allOf": [
+            {"$ref": "#/definitions/linkUrl"},
+            {"description": "Icon associated with the message"}
+          ]
+        },
+        "icon_dark_theme": {
+          "type": "string",
+          "description": "Pop-over icon, dark theme variant. Should be 32x32px or 64x64px and png/svg."
+        },
+        "icon_class": {
+          "type": "string",
+          "description": "CSS class of the pop-over icon."
+        },
+        "addon": {
+          "description": "Addon information including AMO URL.",
+          "type": "object",
+          "properties": {
+            "id": {
+              "allOf": [
+                {"$ref": "#/definitions/plainText"},
+                {"description": "Unique addon ID"}
+              ]
+            },
+            "title": {
+              "allOf": [
+                {"$ref": "#/definitions/plainText"},
+                {"description": "Addon name"}
+              ]
+            },
+            "author": {
+              "allOf": [
+                {"$ref": "#/definitions/plainText"},
+                {"description": "Addon author"}
+              ]
+            },
+            "icon": {
+              "description": "The icon displayed in the pop-over. Should be 64x64px and png/svg.",
+              "allOf": [
+                {"$ref": "#/definitions/linkUrl"},
+                {"description": "Addon icon"}
+              ]
+            },
+            "rating": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 5,
+              "description": "Star rating"
+            },
+            "users": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Installed users"
+            },
+            "amo_url": {
+              "allOf": [
+                {"$ref": "#/definitions/linkUrl"},
+                {"description": "Link that offers more information related to the addon."}
+              ]
+            }
+          },
+          "required": ["title", "author", "icon", "amo_url"]
+        },
+        "text": {
+          "description": "The body text displayed in the pop-over. This can be a reference to a localized string in Firefox or just a plain string.",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Description message of the addon."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "string_id": {
+                  "type": "string",
+                  "description": "Id of string to localized addon description"
+                }
+              },
+              "required": ["string_id"]
+            }
+          ]
+        },
+        "descriptionDetails": {
+          "description": "Additional information and steps on how to use",
+          "type": "object",
+          "properties": {
+            "steps": {
+              "description": "Array of messages or string_ids",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "string_id": {
+                    "type": "string",
+                    "description": "Id of string to localized addon description"
+                  }
+                },
+                "required": ["string_id"]
+              }
+            }
+          },
+          "required": ["steps"]
+        },
+        "buttons": {
+          "description": "The label and functionality for the buttons in the pop-over.",
+          "type": "object",
+          "properties": {
+            "primary": {
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "object",
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "value": {
+                          "allOf": [
+                            {"$ref": "#/definitions/plainText"},
+                            {"description": "Button label override used when a localized version is not available."}
+                          ]
+                        },
+                        "attributes": {
+                          "type": "object",
+                          "properties": {
+                            "accesskey": {
+                              "type": "string",
+                              "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                            }
+                          },
+                          "required": ["accesskey"],
+                          "description": "Button attributes."
+                        }
+                      },
+                      "required": ["value", "attributes"]
+                    },
+                    {
+                      "properties": {
+                        "string_id": {
+                          "allOf": [
+                            {"$ref": "#/definitions/plainText"},
+                            {"description": "Id of localized string for button"}
+                          ]
+                        }
+                      },
+                      "required": ["string_id"]
+                    }
+                  ],
+                  "description": "Id of localized string or message override."
+                },
+                "action": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "Action dispatched by the button."
+                    },
+                    "data": {
+                      "properties": {
+                        "url": {
+                          "type": "null",
+                          "$comment": "This is dynamically generated from the addon.id. See CFRPageActions.jsm",
+                          "description": "URL used in combination with the primary action dispatched."
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "secondary": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "object",
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "allOf": [
+                              {"$ref": "#/definitions/plainText"},
+                              {"description": "Button label override used when a localized version is not available."}
+                            ]
+                          },
+                          "attributes": {
+                            "type": "object",
+                            "properties": {
+                              "accesskey": {
+                                "type": "string",
+                                "description": "A single character to be used as a shortcut key for the secondary button. This should be one of the characters that appears in the button label."
+                              }
+                            },
+                            "required": ["accesskey"],
+                            "description": "Button attributes."
+                          }
+                        },
+                        "required": ["value", "attributes"]
+                      },
+                      {
+                        "properties": {
+                          "string_id": {
+                            "allOf": [
+                              {"$ref": "#/definitions/plainText"},
+                              {"description": "Id of localized string for button"}
+                            ]
+                          }
+                        },
+                        "required": ["string_id"]
+                      }
+                    ],
+                    "description": "Id of localized string or message override."
+                  },
+                  "action": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "description": "Action dispatched by the button."
+                      },
+                      "data": {
+                        "properties": {
+                          "url": {
+                            "allOf": [
+                              {"$ref": "#/definitions/linkUrl"},
+                              {"description": "URL used in combination with the primary action dispatched."}
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": true,
+      "required": ["category", "bucket_id"]
+    },
+    "frequency": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "lifetime": {
+          "type": "integer"
+        },
+        "custom": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "cap": {
+                "type": "integer"
+              },
+              "period": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "priority": {
+      "type": "integer"
+    },
+    "targeting": {
+      "type": "string"
+    },
+    "template": {
+      "type": "string"
+    },
+    "trigger": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "params": {
+          "type": "array"
+        }
+      },
+      "required": ["id"]
+    },
+    "schema": {
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["id", "content", "targeting", "template", "trigger"]
+}

--- a/schema/whats-new-panel.schema.json
+++ b/schema/whats-new-panel.schema.json
@@ -1,0 +1,155 @@
+{
+  "title": "ExtensionDoorhanger",
+  "description": "A template with a heading, addon icon, title and description. No markup allowed.",
+  "version": "1.0.0",
+  "type": "object",
+  "definitions": {
+    "plainText": {
+      "description": "Plain text (no HTML allowed)",
+      "type": "string"
+    },
+    "linkUrl": {
+      "description": "Target for links or buttons",
+      "type": "string",
+      "format": "uri"
+    },
+    "stringOrStringID": {
+      "description": "This can be a reference to a localized string in Firefox or just a plain string.",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Description message of the addon."
+        },
+        {
+          "type": "object",
+          "properties": {
+            "string_id": {
+              "type": "string",
+              "description": "Id of string to localized addon description"
+            }
+          },
+          "required": ["string_id"]
+        }
+      ]
+    }
+  },
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Message identifier"
+    },
+    "content": {
+      "type": "object",
+      "properties": {
+        "layout": {
+          "type": "string",
+          "description": "Attribute used for different groups of messages from the same provider"
+        },
+        "body": {
+          "description": "This can be a reference to a localized string in Firefox or just a plain string.",
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Description message of the addon."
+            },
+            {
+              "type": "object",
+              "properties": {
+                "string_id": {
+                  "type": "string",
+                  "description": "Id of string to localized addon description"
+                }
+              },
+              "required": ["string_id"]
+            }
+          ]
+        },
+        "bucket_id": {
+          "type": "string",
+          "description": "A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting."
+        },
+        "cta_type": {
+          "type": "string"
+        },
+        "cta_url": {
+          "$ref": "#/definitions/linkUrl"
+        },
+        "icon_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/linkUrl"
+            }
+          ]
+        },
+        "link_text": {
+          "$ref": "#/definitions/stringOrStringID"
+        },
+        "published_date": {
+          "type": "integer"
+        },
+        "title": {
+          "$ref": "#/definitions/stringOrStringID"
+        },
+        "delay": {
+          "type": "integer"
+        },
+        "target": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "required": ["bucket_id"]
+    },
+    "frequency": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "lifetime": {
+          "type": "integer"
+        },
+        "custom": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "cap": {
+                "type": "integer"
+              },
+              "period": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "priority": {
+      "type": "integer"
+    },
+    "order": {
+      "type": "integer"
+    },
+    "targeting": {
+      "type": "string"
+    },
+    "template": {
+      "type": "string"
+    },
+    "trigger": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "params": {
+          "type": "array"
+        }
+      },
+      "required": ["id"]
+    }
+  },
+  "additionalProperties": false,
+  "required": ["id", "content", "targeting", "template", "trigger"]
+}

--- a/schema/whats-new-panel.schema.json
+++ b/schema/whats-new-panel.schema.json
@@ -105,22 +105,43 @@
     },
     "frequency": {
       "type": "object",
-      "additionalProperties": false,
+      "description": "An object containing frequency cap information for a message.",
       "properties": {
         "lifetime": {
-          "type": "integer"
+          "type": "integer",
+          "description": "The maximum lifetime impressions for a message.",
+          "minimum": 1,
+          "maximum": 100
         },
         "custom": {
           "type": "array",
+          "description": "An array of custom frequency cap definitions.",
           "items": {
+            "description": "A frequency cap definition containing time and max impression information",
+            "type": "object",
             "properties": {
-              "cap": {
-                "type": "integer"
-              },
               "period": {
-                "type": "integer"
+                "oneOf": [
+                  {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  {
+                    "type": "string",
+                    "description": "One of a preset list of short forms for period of time (e.g. 'daily' for one day)",
+                    "enum": ["daily"]
+                  }
+                ]
+
+              },
+              "cap": {
+                "type": "integer",
+                "description": "The maximum impressions for the message within the defined period.",
+                "minimum": 1,
+                "maximum": 100
               }
-            }
+            },
+            "required": ["period", "cap"]
           }
         }
       }
@@ -129,22 +150,34 @@
       "type": "integer"
     },
     "order": {
-      "type": "integer"
+      "type": "integer",
+      "minimum": 0,
+      "description": "If bundled with other messages of the same template, which order should this one be placed in? (optional - defaults to 0)"
     },
     "targeting": {
-      "type": "string"
+      "type": "string",
+      "description": "A JEXL expression representing targeting information"
     },
     "template": {
       "type": "string"
     },
     "trigger": {
       "type": "object",
+      "description": "An action to trigger potentially showing the message",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "A string identifying the trigger action"
         },
         "params": {
-          "type": "array"
+          "type": "array",
+          "description": "An optional array of string parameters for the trigger action",
+          "items": {
+            "anyOf": [
+              { "type": "integer" },
+              { "type": "string" }
+            ]
+          }
         }
       },
       "required": ["id"]

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+
+import jsonschema
+
+
+USAGE = """
+    Usage:
+        validate.py ${JSON_PATH} ${SCHEMA_PATH}
+
+    Exmaple:
+        validate.py ./cfr.json ./schema/cfr.schema.json
+"""
+
+
+def validate(src_path, schema_path):
+    with open(schema_path, "r") as f:
+        schema = json.loads(f.read())
+
+    with open(src_path, "r") as f:
+        items = json.loads(f.read())
+        for item in items:
+            jsonschema.validate(instance=item, schema=schema)
+
+    print("Passed!")
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 3:
+        print(USAGE)
+        sys.exit(1)
+
+    validate(sys.argv[1], sys.argv[2])

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -5,6 +5,8 @@ import sys
 
 import jsonschema
 
+from jsonschema.exceptions import best_match, ValidationError
+
 
 USAGE = """
     Usage:
@@ -22,7 +24,12 @@ def validate(src_path, schema_path):
     with open(src_path, "r") as f:
         items = json.loads(f.read())
         for item in items:
-            jsonschema.validate(instance=item, schema=schema)
+            try:
+                jsonschema.validate(instance=item, schema=schema)
+            except ValidationError as err:
+                match = best_match([err])
+                print("Validation error: {}".format(match.message))
+                sys.exit(1)
 
     print("Passed!")
 


### PR DESCRIPTION
This adds the basic schema validation on the JSON assets.

Note that:
* the templates defined in m-c are dated, so I added various items to reflect the current inflight assets
* several properties, such as `schema` for `cfr`, seem quite suspicious to me, let's take a closer look at the schema files to ensure the correctness
* whats-new-panel needs more attention (as I've added quite a bit in there)