### PR TITLE
Disable Awesomebar message for certain locales

### DIFF
--- a/whats-new-panel.json
+++ b/whats-new-panel.json
@@ -300,7 +300,7 @@
         "string_id": "cfr-whatsnew-pip-cta"
       }
     },
-    "targeting": "firefoxVersion >= 75",
+    "targeting": "firefoxVersion >= 75 &&\n!(locale in [\"ach\", \"af\", \"ast\", \"az\", \"bg\", \"bn\", \"bo\", \"br\", \"brx\",\n\"ca-valencia\", \"ca\", \"el\", \"et\", \"fa\", \"ff\", \"fi\", \"ga-IE\", \"gl\", \"gu-IN\",\n\"hi-IN\", \"hy-AM\", \"is\", \"km\", \"kn\", \"lij\", \"lo\", \"ltg\", \"lv\", \"mk\", \"mr\",\n\"ms\", \"my\", \"ne-NP\", \"scn\", \"si\", \"sk\", \"sr\", \"ta\", \"te\", \"tl\", \"trs\", \"ur\"])\n",
     "trigger": {
       "id": "whatsNewPanelOpened"
     }

--- a/whats-new-panel.yaml
+++ b/whats-new-panel.yaml
@@ -238,7 +238,13 @@
     cta_type: OPEN_URL
     link_text:
       string_id: cfr-whatsnew-pip-cta
-  targeting: firefoxVersion >= 75
+  # Exclude those locales due to the missing stringIDs
+  targeting: |
+    firefoxVersion >= 75 &&
+    !(locale in ["ach", "af", "ast", "az", "bg", "bn", "bo", "br", "brx",
+    "ca-valencia", "ca", "el", "et", "fa", "ff", "fi", "ga-IE", "gl", "gu-IN",
+    "hi-IN", "hy-AM", "is", "km", "kn", "lij", "lo", "ltg", "lv", "mk", "mr",
+    "ms", "my", "ne-NP", "scn", "si", "sk", "sr", "ta", "te", "tl", "trs", "ur"])
   trigger:
     id: whatsNewPanelOpened
 - id: WHATS_NEW_BADGE_75


### PR DESCRIPTION
This pulls the AwesomeBar whats-new-panel message for locales that do not have the necessary string IDs.

Since this is the only new feature in 75, shall we consider disabling the WNP as a whole?

Still waiting for the call to see if we want this fix other than patching remote fluent files.  