### PR TITLE
Bug 1633347 - Deploy What's New Badge for 76

### DIFF
--- a/whats-new-panel-archived.json
+++ b/whats-new-panel-archived.json
@@ -291,5 +291,85 @@
     "trigger": {
       "id": "whatsNewPanelOpened"
     }
+  },
+  {
+    "id": "WHATS_NEW_BADGE_75",
+    "content": {
+      "action": {
+        "id": "show-whatsnew-button"
+      },
+      "badgeDescription": {
+        "string_id": "cfr-badge-reader-label-newfeature"
+      },
+      "bucket_id": "WHATS_NEW_BADGE_75",
+      "delay": 300000,
+      "target": "whats-new-menu-button"
+    },
+    "frequency": {
+      "lifetime": 100
+    },
+    "priority": 5,
+    "targeting": "firefoxVersion == 75 && (usesFirefoxSync || hasAccessedFxAPanel || currentDate|date - 2419200000 >= profileAgeCreated) && (!messageImpressions['WHATS_NEW_BADGE_75'] || (messageImpressions['WHATS_NEW_BADGE_75']|length >= 1 && currentDate|date - messageImpressions['WHATS_NEW_BADGE_75'][0] <= 345600000)) && 'browser.messaging-system.whatsNewPanel.enabled'|preferenceValue",
+    "template": "toolbar_badge",
+    "trigger": {
+      "id": "toolbarBadgeUpdate"
+    }
+  },
+  {
+    "id": "WHATS_NEW_FINGERPRINTER_COUNTER_72",
+    "content": {
+      "body": {
+        "string_id": "cfr-whatsnew-fingerprinter-counter-body"
+      },
+      "bucket_id": "WHATS_NEW_FINGERPRINTER_COUNTER_72",
+      "cta_type": "OPEN_ABOUT_PAGE",
+      "cta_url": "protections",
+      "icon_alt": "",
+      "icon_url": "resource://activity-stream/data/content/assets/protection-report-icon.png",
+      "layout": "tracking-protections",
+      "layout_title_content_variable": "fingerprinterCount",
+      "link_text": {
+        "string_id": "cfr-whatsnew-tracking-blocked-link-text"
+      },
+      "published_date": 1578405980832,
+      "subtitle": {
+        "string_id": "cfr-whatsnew-tracking-blocked-subtitle"
+      },
+      "title": {
+        "string_id": "cfr-whatsnew-fingerprinter-counter-header"
+      }
+    },
+    "order": 3,
+    "targeting": "firefoxVersion >= 72 && blockedCountByType.fingerprinterCount >= 10",
+    "template": "whatsnew_panel_message",
+    "trigger": {
+      "id": "whatsNewPanelOpened"
+    }
+  },
+  {
+    "id": "WHATS_NEW_FINGERPRINTER_COUNTER_ALT",
+    "content": {
+      "body": {
+        "string_id": "cfr-whatsnew-fingerprinter-counter-body-alt"
+      },
+      "bucket_id": "WHATS_NEW_FINGERPRINTER_COUNTER_ALT",
+      "cta_type": "OPEN_ABOUT_PAGE",
+      "cta_url": "protections",
+      "icon_alt": "",
+      "icon_url": "resource://activity-stream/data/content/assets/protection-report-icon.png",
+      "link_text": {
+        "string_id": "cfr-whatsnew-tracking-blocked-link-text"
+      },
+      "published_date": 1578405980832,
+      "title": {
+        "string_id": "cfr-whatsnew-fingerprinter-counter-header-alt"
+      }
+    },
+    "order": 3,
+    "targeting": "firefoxVersion >= 72 && blockedCountByType.fingerprinterCount < 10",
+    "template": "whatsnew_panel_message",
+    "trigger": {
+      "id": "whatsNewPanelOpened"
+    }
   }
 ]

--- a/whats-new-panel-archived.yaml
+++ b/whats-new-panel-archived.yaml
@@ -235,3 +235,64 @@
   template: whatsnew_panel_message
   trigger:
     id: whatsNewPanelOpened
+- id: WHATS_NEW_BADGE_75
+  content:
+    action:
+      id: show-whatsnew-button
+    badgeDescription:
+      string_id: cfr-badge-reader-label-newfeature
+    bucket_id: WHATS_NEW_BADGE_75
+    delay: 300000
+    target: whats-new-menu-button
+  frequency:
+    lifetime: 100
+  priority: 5
+  targeting: firefoxVersion == 75 && (usesFirefoxSync || hasAccessedFxAPanel || currentDate|date
+    - 2419200000 >= profileAgeCreated) && (!messageImpressions['WHATS_NEW_BADGE_75']
+    || (messageImpressions['WHATS_NEW_BADGE_75']|length >= 1 && currentDate|date -
+    messageImpressions['WHATS_NEW_BADGE_75'][0] <= 345600000)) && 'browser.messaging-system.whatsNewPanel.enabled'|preferenceValue
+  template: toolbar_badge
+  trigger:
+    id: toolbarBadgeUpdate
+- id: WHATS_NEW_FINGERPRINTER_COUNTER_72
+  content:
+    body:
+      string_id: cfr-whatsnew-fingerprinter-counter-body
+    bucket_id: WHATS_NEW_FINGERPRINTER_COUNTER_72
+    cta_type: OPEN_ABOUT_PAGE
+    cta_url: protections
+    icon_alt: ''
+    icon_url: resource://activity-stream/data/content/assets/protection-report-icon.png
+    layout: tracking-protections
+    layout_title_content_variable: fingerprinterCount
+    link_text:
+      string_id: cfr-whatsnew-tracking-blocked-link-text
+    published_date: 1578405980832
+    subtitle:
+      string_id: cfr-whatsnew-tracking-blocked-subtitle
+    title:
+      string_id: cfr-whatsnew-fingerprinter-counter-header
+  order: 3
+  targeting: firefoxVersion >= 72 && blockedCountByType.fingerprinterCount >= 10
+  template: whatsnew_panel_message
+  trigger:
+    id: whatsNewPanelOpened
+- id: WHATS_NEW_FINGERPRINTER_COUNTER_ALT
+  content:
+    body:
+      string_id: cfr-whatsnew-fingerprinter-counter-body-alt
+    bucket_id: WHATS_NEW_FINGERPRINTER_COUNTER_ALT
+    cta_type: OPEN_ABOUT_PAGE
+    cta_url: protections
+    icon_alt: ''
+    icon_url: resource://activity-stream/data/content/assets/protection-report-icon.png
+    link_text:
+      string_id: cfr-whatsnew-tracking-blocked-link-text
+    published_date: 1578405980832
+    title:
+      string_id: cfr-whatsnew-fingerprinter-counter-header-alt
+  order: 3
+  targeting: firefoxVersion >= 72 && blockedCountByType.fingerprinterCount < 10
+  template: whatsnew_panel_message
+  trigger:
+    id: whatsNewPanelOpened

--- a/whats-new-panel.json
+++ b/whats-new-panel.json
@@ -1,88 +1,5 @@
 [
   {
-    "id": "WHATS_NEW_FINGERPRINTER_COUNTER_72",
-    "content": {
-      "body": {
-        "string_id": "cfr-whatsnew-fingerprinter-counter-body"
-      },
-      "bucket_id": "WHATS_NEW_FINGERPRINTER_COUNTER_72",
-      "cta_type": "OPEN_ABOUT_PAGE",
-      "cta_url": "protections",
-      "icon_alt": "",
-      "icon_url": "resource://activity-stream/data/content/assets/protection-report-icon.png",
-      "layout": "tracking-protections",
-      "layout_title_content_variable": "fingerprinterCount",
-      "link_text": {
-        "string_id": "cfr-whatsnew-tracking-blocked-link-text"
-      },
-      "published_date": 1578405980832,
-      "subtitle": {
-        "string_id": "cfr-whatsnew-tracking-blocked-subtitle"
-      },
-      "title": {
-        "string_id": "cfr-whatsnew-fingerprinter-counter-header"
-      }
-    },
-    "order": 3,
-    "targeting": "firefoxVersion >= 72 && blockedCountByType.fingerprinterCount >= 10",
-    "template": "whatsnew_panel_message",
-    "trigger": {
-      "id": "whatsNewPanelOpened"
-    }
-  },
-  {
-    "id": "WHATS_NEW_FINGERPRINTER_COUNTER_ALT",
-    "content": {
-      "body": {
-        "string_id": "cfr-whatsnew-fingerprinter-counter-body-alt"
-      },
-      "bucket_id": "WHATS_NEW_FINGERPRINTER_COUNTER_ALT",
-      "cta_type": "OPEN_ABOUT_PAGE",
-      "cta_url": "protections",
-      "icon_alt": "",
-      "icon_url": "resource://activity-stream/data/content/assets/protection-report-icon.png",
-      "link_text": {
-        "string_id": "cfr-whatsnew-tracking-blocked-link-text"
-      },
-      "published_date": 1578405980832,
-      "title": {
-        "string_id": "cfr-whatsnew-fingerprinter-counter-header-alt"
-      }
-    },
-    "order": 3,
-    "targeting": "firefoxVersion >= 72 && blockedCountByType.fingerprinterCount < 10",
-    "template": "whatsnew_panel_message",
-    "trigger": {
-      "id": "whatsNewPanelOpened"
-    }
-  },
-  {
-    "id": "WHATS_NEW_PIP_72",
-    "content": {
-      "body": {
-        "string_id": "cfr-whatsnew-pip-body"
-      },
-      "bucket_id": "WHATS_NEW_PIP_72",
-      "cta_type": "OPEN_URL",
-      "cta_url": "https://support.mozilla.org/1/firefox/%VERSION%/%OS%/%LOCALE%/about-p2p",
-      "icon_alt": "",
-      "icon_url": "resource://activity-stream/data/content/assets/remote/pip-message-icon.svg",
-      "link_text": {
-        "string_id": "cfr-whatsnew-pip-cta"
-      },
-      "published_date": 1578405980832,
-      "title": {
-        "string_id": "cfr-whatsnew-pip-header"
-      }
-    },
-    "order": 1,
-    "targeting": "firefoxVersion >= 72 && firefoxVersion < 76",
-    "template": "whatsnew_panel_message",
-    "trigger": {
-      "id": "whatsNewPanelOpened"
-    }
-  },
-  {
     "id": "WHATS_NEW_AWESOMEBAR_75",
     "template": "whatsnew_panel_message",
     "order": 1,
@@ -105,13 +22,13 @@
         "string_id": "cfr-whatsnew-pip-cta"
       }
     },
-    "targeting": "firefoxVersion >= 75",
+    "targeting": "firefoxVersion == 75",
     "trigger": {
       "id": "whatsNewPanelOpened"
     }
   },
   {
-    "id": "WHATS_NEW_BADGE_75",
+    "id": "WHATS_NEW_BADGE_76",
     "content": {
       "action": {
         "id": "show-whatsnew-button"
@@ -119,7 +36,7 @@
       "badgeDescription": {
         "string_id": "cfr-badge-reader-label-newfeature"
       },
-      "bucket_id": "WHATS_NEW_BADGE_75",
+      "bucket_id": "WHATS_NEW_BADGE_76",
       "delay": 300000,
       "target": "whats-new-menu-button"
     },
@@ -127,7 +44,7 @@
       "lifetime": 100
     },
     "priority": 5,
-    "targeting": "firefoxVersion == 75 && (usesFirefoxSync || hasAccessedFxAPanel || currentDate|date - 2419200000 >= profileAgeCreated) && (!messageImpressions['WHATS_NEW_BADGE_75'] || (messageImpressions['WHATS_NEW_BADGE_75']|length >= 1 && currentDate|date - messageImpressions['WHATS_NEW_BADGE_75'][0] <= 345600000)) && 'browser.messaging-system.whatsNewPanel.enabled'|preferenceValue",
+    "targeting": "firefoxVersion == 76 && (usesFirefoxSync || hasAccessedFxAPanel || currentDate|date - 2419200000 >= profileAgeCreated) && (!messageImpressions['WHATS_NEW_BADGE_76'] || (messageImpressions['WHATS_NEW_BADGE_76']|length >= 1 && currentDate|date - messageImpressions['WHATS_NEW_BADGE_76'][0] <= 345600000)) && 'browser.messaging-system.whatsNewPanel.enabled'|preferenceValue",
     "template": "toolbar_badge",
     "trigger": {
       "id": "toolbarBadgeUpdate"

--- a/whats-new-panel.yaml
+++ b/whats-new-panel.yaml
@@ -1,64 +1,3 @@
-- id: WHATS_NEW_FINGERPRINTER_COUNTER_72
-  content:
-    body:
-      string_id: cfr-whatsnew-fingerprinter-counter-body
-    bucket_id: WHATS_NEW_FINGERPRINTER_COUNTER_72
-    cta_type: OPEN_ABOUT_PAGE
-    cta_url: protections
-    icon_alt: ''
-    icon_url: resource://activity-stream/data/content/assets/protection-report-icon.png
-    layout: tracking-protections
-    layout_title_content_variable: fingerprinterCount
-    link_text:
-      string_id: cfr-whatsnew-tracking-blocked-link-text
-    published_date: 1578405980832
-    subtitle:
-      string_id: cfr-whatsnew-tracking-blocked-subtitle
-    title:
-      string_id: cfr-whatsnew-fingerprinter-counter-header
-  order: 3
-  targeting: firefoxVersion >= 72 && blockedCountByType.fingerprinterCount >= 10
-  template: whatsnew_panel_message
-  trigger:
-    id: whatsNewPanelOpened
-- id: WHATS_NEW_FINGERPRINTER_COUNTER_ALT
-  content:
-    body:
-      string_id: cfr-whatsnew-fingerprinter-counter-body-alt
-    bucket_id: WHATS_NEW_FINGERPRINTER_COUNTER_ALT
-    cta_type: OPEN_ABOUT_PAGE
-    cta_url: protections
-    icon_alt: ''
-    icon_url: resource://activity-stream/data/content/assets/protection-report-icon.png
-    link_text:
-      string_id: cfr-whatsnew-tracking-blocked-link-text
-    published_date: 1578405980832
-    title:
-      string_id: cfr-whatsnew-fingerprinter-counter-header-alt
-  order: 3
-  targeting: firefoxVersion >= 72 && blockedCountByType.fingerprinterCount < 10
-  template: whatsnew_panel_message
-  trigger:
-    id: whatsNewPanelOpened
-- id: WHATS_NEW_PIP_72
-  content:
-    body:
-      string_id: cfr-whatsnew-pip-body
-    bucket_id: WHATS_NEW_PIP_72
-    cta_type: OPEN_URL
-    cta_url: https://support.mozilla.org/1/firefox/%VERSION%/%OS%/%LOCALE%/about-p2p
-    icon_alt: ''
-    icon_url: resource://activity-stream/data/content/assets/remote/pip-message-icon.svg
-    link_text:
-      string_id: cfr-whatsnew-pip-cta
-    published_date: 1578405980832
-    title:
-      string_id: cfr-whatsnew-pip-header
-  order: 1
-  targeting: firefoxVersion >= 72 && firefoxVersion < 76
-  template: whatsnew_panel_message
-  trigger:
-    id: whatsNewPanelOpened
 - id: WHATS_NEW_AWESOMEBAR_75
   template: whatsnew_panel_message
   order: 1
@@ -76,25 +15,25 @@
     cta_type: OPEN_URL
     link_text:
       string_id: cfr-whatsnew-pip-cta
-  targeting: firefoxVersion >= 75
+  targeting: firefoxVersion == 75
   trigger:
     id: whatsNewPanelOpened
-- id: WHATS_NEW_BADGE_75
+- id: WHATS_NEW_BADGE_76
   content:
     action:
       id: show-whatsnew-button
     badgeDescription:
       string_id: cfr-badge-reader-label-newfeature
-    bucket_id: WHATS_NEW_BADGE_75
+    bucket_id: WHATS_NEW_BADGE_76
     delay: 300000
     target: whats-new-menu-button
   frequency:
     lifetime: 100
   priority: 5
-  targeting: firefoxVersion == 75 && (usesFirefoxSync || hasAccessedFxAPanel || currentDate|date
-    - 2419200000 >= profileAgeCreated) && (!messageImpressions['WHATS_NEW_BADGE_75']
-    || (messageImpressions['WHATS_NEW_BADGE_75']|length >= 1 && currentDate|date -
-    messageImpressions['WHATS_NEW_BADGE_75'][0] <= 345600000)) && 'browser.messaging-system.whatsNewPanel.enabled'|preferenceValue
+  targeting: firefoxVersion == 76 && (usesFirefoxSync || hasAccessedFxAPanel || currentDate|date
+    - 2419200000 >= profileAgeCreated) && (!messageImpressions['WHATS_NEW_BADGE_76']
+    || (messageImpressions['WHATS_NEW_BADGE_76']|length >= 1 && currentDate|date -
+    messageImpressions['WHATS_NEW_BADGE_76'][0] <= 345600000)) && 'browser.messaging-system.whatsNewPanel.enabled'|preferenceValue
   template: toolbar_badge
   trigger:
     id: toolbarBadgeUpdate


### PR DESCRIPTION
Several changes:
1. Moved 75 badge to archived
2. Created 76 badge
3. Moved all `< 75` messages to archived
4. Updated targeting on 75 awesomebar message to be `== 75`

When syncing to RS I will also sync (4) as for the other message changes (which are already version guarded) I will remove them after after 76 gets to release. This way we won't have a single message showing in release until they upgrade to 76.