### PR TITLE
Require filter expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ pip3 install yamllint
 
 # this is for schema validation
 $ pip3 install jsonschema
+$ pip3 install pyjexl
 ```
 
 Note: make sure you commit all the changes (YAML&JSON) to the repo.

--- a/schema/messaging-experiments.schema.json
+++ b/schema/messaging-experiments.schema.json
@@ -8,11 +8,11 @@
       "type": "string"
     },
     "filter_expression": {
-      "description": "[deprecated] A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting.",
+      "description": "A targeting expression that will be evaluated by Remote Settings. Due to compatbility issues with fx 76, you must always include at least a version filter (e.g. env.version >= '77.')",
       "type": "string"
     },
     "targeting": {
-      "description": "Starting with Firefox 77: A bucket identifier for the addon. This is used in order to anonymize telemetry for history-sensitive targeting.",
+      "description": "Starting with Firefox 77: A targeting expression that will be evaluated with ASRouterTargeting.",
       "type": "string"
     },
     "arguments": {
@@ -70,5 +70,5 @@
       "required": ["slug", "branches"]
     }
   },
-  "required": ["id", "arguments"]
+  "required": ["id", "arguments", "filter_expression"]
 }


### PR DESCRIPTION
Is this OK for now? Basically as long as `filter_expression` is always ` env.version >= '77.'` we are fine (we could even require it to be an `enum` of that in the schema)