### PR TITLE
Add script to import from Experimenter

### DIFF
--- a/scripts/spot.sh
+++ b/scripts/spot.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
+USAGE="Usage:
+
+# list all experiment slugs
+$0
+
+# copy [experiment-slug] arguments to yaml
+$0 [experiment-slug]
+"
+
 PYTHON=python3
 EXPERIMENTER_URL=https://experimenter.services.mozilla.com/api/v1/experiments
 RECIPE_URL=${EXPERIMENTER_URL}/$1/recipe/
 
-if [[ -z $1 ]]; then
+if [ $1 == "-h" ] || [ $1 = "--help" ]; then
+  echo "${USAGE}"
+elif [[ -z $1 ]]; then
   curl -SsL ${EXPERIMENTER_URL}/ | jq -r '.[].slug'
   echo "Choose from one of the available slugs: $0 [slug_name]"
 else
@@ -13,5 +24,5 @@ else
     jq -r '{id: .experimenter_slug, enabled: true, arguments: .arguments, filter_expression: "", targeting: ""}'
   )
   ${PYTHON} -c 'import sys, yaml, json; yaml.dump(json.load(sys.stdin), sys.stdout)
-    '<<<${json_input} > $1.yaml
+    '<<< ${json_input} > $1.yaml
 fi

--- a/scripts/spot.sh
+++ b/scripts/spot.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+PYTHON=python3
+EXPERIMENTER_URL=https://experimenter.services.mozilla.com/api/v1/experiments
+RECIPE_URL=${EXPERIMENTER_URL}/$1/recipe/
+
+if [[ -z $1 ]]; then
+  curl -SsL ${EXPERIMENTER_URL}/ | jq -r '.[].slug'
+  echo "Choose from one of the available slugs: $0 <slug_name>"
+else
+  json_input=$(curl -SsL ${RECIPE_URL} | jq -r '.arguments')
+  ${PYTHON} -c 'import sys, yaml, json; yaml.dump(json.load(sys.stdin), sys.stdout)
+    '<<<${json_input} > $1.yaml
+fi

--- a/scripts/spot.sh
+++ b/scripts/spot.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
+
 PYTHON=python3
 EXPERIMENTER_URL=https://experimenter.services.mozilla.com/api/v1/experiments
 RECIPE_URL=${EXPERIMENTER_URL}/$1/recipe/
 
 if [[ -z $1 ]]; then
   curl -SsL ${EXPERIMENTER_URL}/ | jq -r '.[].slug'
-  echo "Choose from one of the available slugs: $0 <slug_name>"
+  echo "Choose from one of the available slugs: $0 [slug_name]"
 else
-  json_input=$(curl -SsL ${RECIPE_URL} | jq -r '.arguments')
+  json_input=$(
+    curl -SsL ${RECIPE_URL} |\
+    jq -r '{id: .experimenter_slug, enabled: true, arguments: .arguments, filter_expression: "", targeting: ""}'
+  )
   ${PYTHON} -c 'import sys, yaml, json; yaml.dump(json.load(sys.stdin), sys.stdout)
     '<<<${json_input} > $1.yaml
 fi


### PR DESCRIPTION
If you run it on it's own it will report all experiment slug names from Experimenter.
If you run it with a slug name it will generate a `slug_name.yaml` file prefilled with the required experiment message fields and the `arguments` part provided by Experimenter.
Alternatively I was thinking we can append to `messaging-experiments.yaml`.