### PR TITLE
Add schema validation for Special Message Actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON = python3
 FLAGS = -c
 CMD = 'import sys, yaml, json; json.dump(yaml.load(sys.stdin, Loader=yaml.Loader), sys.stdout, indent=2)'
 
-all: cfr.json cfr-fxa.json cfr-heartbeat.json whats-new-panel.json messaging-experiments.json 
+all: cfr.json cfr-fxa.json cfr-heartbeat.json whats-new-panel.json messaging-experiments.json
 
 %.json:%.yaml pre-build
 	$(PYTHON) $(FLAGS) $(CMD) < $< > $@
@@ -16,7 +16,7 @@ clean:
 	rm *.json
 
 check:
-	scripts/validate.py cfr.json schema/cfr.schema.json
-	scripts/validate.py cfr-fxa.json schema/cfr-fxa.schema.json
-	scripts/validate.py whats-new-panel.json schema/whats-new-panel.schema.json
-	scripts/validate.py messaging-experiments.json schema/messaging-experiments.schema.json
+	scripts/validate.py cfr cfr.json
+	scripts/validate.py cfr-fxa cfr-fxa.json
+	scripts/validate.py whats-new-panel whats-new-panel.json
+	scripts/validate.py messaging-experiments messaging-experiments.json

--- a/schema/messaging-system-special-message-actions.schema.json
+++ b/schema/messaging-system-special-message-actions.schema.json
@@ -51,7 +51,7 @@
             "type": "string"
           },
           "url": {
-            "type": "string"
+            "type": ["string", "null"]
           }
         },
         "type": "object"

--- a/schema/messaging-system-special-message-actions.schema.json
+++ b/schema/messaging-system-special-message-actions.schema.json
@@ -1,0 +1,264 @@
+{
+  "CANCEL": {
+    "description": "Cancel (dismiss) the CFR doorhanger.",
+    "properties": {
+      "type": {
+        "enum": ["CANCEL"],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "DISABLE_STP_DOORHANGERS": {
+    "description": "Disables all STP doorhangers.",
+    "properties": {
+      "type": {
+        "enum": [
+          "DISABLE_STP_DOORHANGERS"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "HIGHLIGHT_FEATURE": {
+    "description": "Highlights an element, such as a menu item.",
+    "properties": {
+      "data": {
+        "properties": {
+          "args": {
+            "description": "The element to highlight",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": {
+        "enum": [
+          "HIGHLIGHT_FEATURE"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "INSTALL_ADDON_FROM_URL": {
+    "description": "Install an add-on from AMO.",
+    "properties": {
+      "data": {
+        "properties": {
+          "telemetrySource": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": {
+        "enum": [
+          "INSTALL_ADDON_FROM_URL"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "OPEN_ABOUT_PAGE": {
+    "description": "Opens an about: page in Firefox",
+    "properties": {
+      "data": {
+        "properties": {
+          "args": {
+            "description": "The about page. E.g. \"welcome\" for about:welcome",
+            "type": "string"
+          },
+          "entrypoint": {
+            "description": "Any optional entrypoint value that will be added to the search. E.g. \"foo=bar\" would result in about:welcome?foo=bar",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": {
+        "enum": [
+          "OPEN_ABOUT_PAGE"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "OPEN_APPLICATIONS_MENU": {
+    "description": "Opens an application menu",
+    "properties": {
+      "data": {
+        "properties": {
+          "args": {
+            "description": "The menu name, e.g. \"appMenu\"",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": {
+        "enum": [
+          "OPEN_APPLICATIONS_MENU"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "OPEN_AWESOME_BAR": {
+    "description": "Focuses and expands the awesome bar.",
+    "properties": {
+      "type": {
+        "enum": [
+          "OPEN_AWESOME_BAR"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "OPEN_PREFERENCES_PAGE": {
+    "description": "Opens a preference page",
+    "properties": {
+      "data": {
+        "properties": {
+          "category": {
+            "description": "Section of about:preferences, e.g. \"privacy-reports\"",
+            "type": "string"
+          },
+          "entrypoint": {
+            "description": "Add a queryparam for metrics",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": {
+        "enum": [
+          "OPEN_PREFERENCES_PAGE"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "OPEN_PRIVATE_BROWSER_WINDOW": {
+    "description": "Opens a private browsing window.",
+    "properties": {
+      "type": {
+        "enum": [
+          "OPEN_PRIVATE_BROWSER_WINDOW"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "OPEN_PROTECTION_PANEL": {
+    "description": "Opens the protecions panel",
+    "properties": {
+      "type": {
+        "enum": [
+          "OPEN_PROTECTION_PANEL"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "OPEN_PROTECTION_REPORT": {
+    "description": "Opens the protecions report",
+    "properties": {
+      "type": {
+        "enum": [
+          "OPEN_PROTECTION_REPORT"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "OPEN_URL": {
+    "description": "Opens a URL.",
+    "properties": {
+      "data": {
+        "properties": {
+          "args": {
+            "type": "string"
+          },
+          "where": {
+            "default": "currrent",
+            "description": "Where the URL is opened.",
+            "enum": [
+              "current",
+              "save",
+              "tab",
+              "tabshifted",
+              "window"
+            ],
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": {
+        "enum": [
+          "OPEN_URL"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "PIN_CURRENT_TAB": {
+    "description": "Pin the current tab.",
+    "properties": {
+      "type": {
+        "enum": [
+          "PIN_CURRENT_TAB"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "SHOW_FIREFOX_ACCOUNTS": {
+    "description": "Show Firefox Accounts",
+    "properties": {
+      "type": {
+        "enum": [
+          "SHOW_FIREFOX_ACCOUNTS"
+        ],
+        "type": "string"
+      },
+      "data": {
+        "properties": {
+          "entrypoint": {
+            "type": "string",
+            "description": "Adds entrypoint={your value} to the FXA URL"
+          }
+        },
+        "type": "object"
+      }
+    },
+    "type": "object"
+  },
+  "SHOW_MIGRATION_WIZARD": {
+    "description": "Shows the Migration Wizard to import data from another Browser. See https://support.mozilla.org/en-US/kb/import-data-another-browser",
+    "properties": {
+      "type": {
+        "enum": [
+          "SHOW_MIGRATION_WIZARD"
+        ],
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
+}

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -10,7 +10,8 @@ from pyjexl.jexl import JEXL
 
 # Create a jexl evaluator
 EVALUATOR = JEXL()
-EVALUATOR.add_binary_operator('intersect', 40, lambda x, y: set(x).intersection(y))
+EVALUATOR.add_binary_operator(
+    'intersect', 40, lambda x, y: set(x).intersection(y))
 EVALUATOR.add_transform('date', lambda x: 0)
 EVALUATOR.add_transform('length', lambda x: 0)
 EVALUATOR.add_transform('preferenceValue', lambda x: False)
@@ -22,13 +23,37 @@ EVALUATOR.add_transform('stableSample', lambda x, y: False)
 # cache all the known schemas to validate experiments
 ALL_SCHEMAS = dict()
 
+SCHEMA_MAP = {
+    "cfr": "schema/cfr.schema.json",
+    "onboarding": "schema/onboarding.schema.json",
+    "cfr-fxa": "schema/cfr-fxa.schema.json",
+    "cfr-heartbeat": "schema/cfr-heartbeat.schema.json",
+    "messaging-experiments": "schema/messaging-experiments.schema.json",
+    "whats-new-panel": "schema/whats-new-panel.schema.json",
+    "action": "schema/messaging-system-special-message-actions.schema.json"
+}
+
 USAGE = """
     Usage:
-        validate.py ${JSON_PATH} ${SCHEMA_PATH}
+
+        validate.py ${TYPE} ${JSON_PATH}
+
+    Where ${type} should be one of "cfr" "cfr-fxa", "messaging-experiments",
+    "whats-new-panel".
 
     Exmaple:
-        validate.py ./cfr.json ./schema/cfr.schema.json
+        validate.py cfr ./cfr.json
 """
+
+
+def load_schema(name):
+    if name in ALL_SCHEMAS:
+        return ALL_SCHEMAS[name]
+
+    path = SCHEMA_MAP[name]
+    with open(path, "r") as f:
+        ALL_SCHEMAS[name] = json.loads(f.read())
+    return ALL_SCHEMAS[name]
 
 
 def validate_item_targeting(item, for_exp=False):
@@ -49,75 +74,104 @@ def validate_item_targeting(item, for_exp=False):
             sys.exit(1)
 
 
-def load_all_schemas():
-    if len(ALL_SCHEMAS):
-        return
+def validate_action(action, for_exp):
+    indentation = "\t" if for_exp else ""
+    all_action_schemas = load_schema("action")
+    action_type = action["type"]
 
-    possible_schemas = [
-        "schema/cfr.schema.json",
-        "schema/onboarding.schema.json",
-        "schema/cfr-fxa.schema.json",
-        "schema/cfr-heartbeat.schema.json",
-        "schema/messaging-experiments.schema.json",
-        "schema/whats-new-panel.schema.json",
-    ]
-    for path in possible_schemas:
-        with open(path, "r") as f:
-            ALL_SCHEMAS[path] = json.loads(f.read())
+    print("{}Validate message action {}".format(indentation, action_type))
+    if action_type not in all_action_schemas:
+        print("{}Unknown action {}".format(indentation, action_type))
+        sys.exit(1)
+
+    schema = all_action_schemas[action_type]
+    try:
+        jsonschema.validate(instance=action, schema=schema)
+    except ValidationError as err:
+        match = best_match([err])
+        print("{}Validation error: {}".format(indentation, match.message))
+        sys.exit(1)
+
+
+def extract_actions(message, message_type):
+    def _extract_cfr():
+        for name, button in message["content"].get("buttons").items():
+            if name == "primary":
+                yield button["action"]
+            else:
+                for sub_button in button:
+                    if "action" in sub_button:
+                        yield sub_button["action"]
+
+    def _extract_onboarding():
+        for card in message:
+            button = card["content"]["primary_button"]
+            if "action" in button:
+                yield button["action"]
+
+    if message_type == "cfr":
+        yield from _extract_cfr()
+    elif message_type == "onboarding":
+        yield from _extract_onboarding()
+    else:
+        raise KeyError("invalid message type {}".format(message_type))
+
+
+def validate_all_actions(message, message_type, for_exp=False):
+    for action in extract_actions(message, message_type):
+        validate_action(action, for_exp)
 
 
 def get_branch_message(branch_value):
     if "id" in branch_value:
         # CFR messages
-        return branch_value
+        return "cfr", branch_value
     if "cards" in branch_value:
         # Onboarding messages
-        return branch_value.get("cards")
+        return "onboarding", branch_value.get("cards")
 
-    return None
+    return None, None
 
 
 def validate_experiment(item):
-    # Load all the schemas to validate experiment messages
-    load_all_schemas()
-
-    validated = 0
     for branch in item.get("arguments").get("branches"):
-        branch_message = get_branch_message(branch.get("value"))
+        message_type, branch_message = get_branch_message(branch.get("value"))
         if branch_message is None:
-            print("\tSkip branch {} because it's empty".format(branch.get("slug")))
-            validated += 1
+            print(
+                "\tSkip branch {} because it's empty"
+                .format(branch.get("slug"))
+            )
             continue
-        # Try all of the available message schemas
-        for schema_path in ALL_SCHEMAS.keys():
-            try:
-                branch_message_list = branch_message if isinstance(branch_message, list) else [branch_message]
-                for message in branch_message_list:
-                    jsonschema.validate(instance=message, schema=ALL_SCHEMAS.get(schema_path))
-                validated += 1
-                print("\tValidated {} with {}".format(branch.get("slug"), schema_path))
-                break
-            except ValidationError as err:
-                match = best_match([err])
-                print("\tValidation error: {}".format(match.message))
-                print("\tTried to validate {} with {}\n".format(branch.get("slug"), schema_path))
+
+        schema = load_schema(message_type)
+        try:
+            branch_message_list = \
+                branch_message if isinstance(branch_message, list) else [
+                    branch_message]
+            for message in branch_message_list:
+                jsonschema.validate(instance=message, schema=schema)
+            print("\tValidated {} with schema {}".format(
+                branch.get("slug"), message_type))
+        except ValidationError as err:
+            match = best_match([err])
+            print("\tValidation error: {}".format(match.message))
+            exit(1)
 
         # Validate the targeting JEXL if any
         validate_item_targeting(branch_message, True)
 
-    if validated != len(item.get("arguments").get("branches")):
-        print("\tBranches did not validate for {}".format(item.get("id")))
-        sys.exit(1)
+        # Validate all the message actions
+        validate_all_actions(branch_message, message_type, True)
 
 
-def validate(src_path, schema_path):
-    with open(schema_path, "r") as f:
-        schema = json.loads(f.read())
+def validate(schema_name, src_path):
+    schema = load_schema(schema_name)
 
     with open(src_path, "r") as f:
         items = json.loads(f.read())
         for item in items:
             try:
+                print("Validate schema for {}".format(item["id"]))
                 jsonschema.validate(instance=item, schema=schema)
                 # If it's an experiment we want to evaluate the branches
                 if "arguments" in item:

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -95,7 +95,7 @@ def validate_action(action, for_exp):
 
 def extract_actions(message, message_type):
     def _extract_cfr():
-        for name, button in message["content"].get("buttons").items():
+        for name, button in message["content"].get("buttons", {}).items():
             if name == "primary":
                 yield button["action"]
             else:

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -68,8 +68,8 @@ def validate_item_targeting(item, for_exp=False):
         try:
             result = list(EVALUATOR.validate(jexl_expression))
             if len(result) > 0:
-                raise Exception(result[0])
-        except Exception as e:
+                raise SyntaxError(result[0])
+        except SyntaxError as e:
             print(e)
             sys.exit(1)
 
@@ -155,7 +155,7 @@ def validate_experiment(item):
         except ValidationError as err:
             match = best_match([err])
             print("\tValidation error: {}".format(match.message))
-            exit(1)
+            sys.exit(1)
 
         # Validate the targeting JEXL if any
         validate_item_targeting(branch_message, True)

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -166,6 +166,7 @@ def validate_experiment(item):
 
 def validate(schema_name, src_path):
     schema = load_schema(schema_name)
+    check_action = schema_name in ['cfr']
 
     with open(src_path, "r") as f:
         items = json.loads(f.read())
@@ -181,6 +182,8 @@ def validate(schema_name, src_path):
                 print("Validation error: {}".format(match.message))
                 sys.exit(1)
             validate_item_targeting(item)
+            if check_action:
+                validate_all_actions(item, schema_name)
 
     print("Passed!")
 


### PR DESCRIPTION
This adds the schema validation for Special Message Actions defined in [here](https://phabricator.services.mozilla.com/D72633#change-dJAnfcshRskP).

Note:

* A new action was added for the `CANCEL` action
* This currently only validates the actions in `messaging-experiments.json`. There are some schema violations in `cfr.json`, which we might want to fix and enable the validation later
* It refactors the x-man experiment validation so that it only validates the branch against the inferred message schema
* It also changes the argument type for `validate.py`, such that only the schema type is required other than the schema path  

This fixes #64.