### PR TITLE
Add group configuration message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON = python3
 FLAGS = -c
 CMD = 'import sys, yaml, json; json.dump(yaml.load(sys.stdin, Loader=yaml.Loader), sys.stdout, indent=2)'
 
-all: cfr.json cfr-fxa.json cfr-heartbeat.json whats-new-panel.json messaging-experiments.json
+all: cfr.json cfr-fxa.json cfr-heartbeat.json whats-new-panel.json messaging-experiments.json message-groups.json
 
 %.json:%.yaml pre-build
 	$(PYTHON) $(FLAGS) $(CMD) < $< > $@
@@ -20,3 +20,4 @@ check:
 	scripts/validate.py cfr-fxa cfr-fxa.json
 	scripts/validate.py whats-new-panel whats-new-panel.json
 	scripts/validate.py messaging-experiments messaging-experiments.json
+	scripts/validate.py message-groups message-groups.json

--- a/message-groups.json
+++ b/message-groups.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "messaging-experiments",
+    "enabled": true,
+    "type": "remote-settings"
+  }
+]

--- a/message-groups.yaml
+++ b/message-groups.yaml
@@ -1,0 +1,3 @@
+- id: messaging-experiments
+  enabled: true
+  type: "remote-settings"

--- a/schema/message-groups.schema.json
+++ b/schema/message-groups.schema.json
@@ -1,0 +1,73 @@
+{
+  "title": "MessageGroup",
+  "description": "Configuration object for groups of Messaging System messages",
+  "type": "object",
+  "version": "1.0.0",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "A unique identifier for the message that should not conflict with any other previous message."
+    },
+    "enabled": {
+      "type": "boolean",
+      "description": "Enables or disables all messages associated with this group."
+    },
+    "userPreferences": {
+      "type": "array",
+      "description": "Collection of preferences that control if the group is enabled.",
+      "items": {
+        "type": "string",
+        "description": "Preference name"
+      }
+    },
+    "frequency": {
+      "type": "object",
+      "description": "An object containing frequency cap information for a message.",
+      "properties": {
+        "lifetime": {
+          "type": "integer",
+          "description": "The maximum lifetime impressions for a message.",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "custom": {
+          "type": "array",
+          "description": "An array of custom frequency cap definitions.",
+          "items": {
+            "description": "A frequency cap definition containing time and max impression information",
+            "type": "object",
+            "properties": {
+              "period": {
+                "oneOf": [
+                  {
+                    "type": "integer",
+                    "description": "Period of time in milliseconds (e.g. 86400000 for one day)"
+                  },
+                  {
+                    "type": "string",
+                    "description": "One of a preset list of short forms for period of time (e.g. 'daily' for one day)",
+                    "enum": ["daily"]
+                  }
+                ]
+
+              },
+              "cap": {
+                "type": "integer",
+                "description": "The maximum impressions for the message within the defined period.",
+                "minimum": 1,
+                "maximum": 100
+              }
+            },
+            "required": ["period", "cap"]
+          }
+        }
+      }
+    },
+    "type": {
+      "type": "string",
+      "description": "Local auto-generated group or remote group configuration from RS.",
+      "enum": ["remote-settings", "local", "default"]
+    }
+  },
+  "required": ["id", "enabled", "type"]
+}

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -31,7 +31,8 @@ SCHEMA_MAP = {
     "cfr-heartbeat": "schema/cfr-heartbeat.schema.json",
     "messaging-experiments": "schema/messaging-experiments.schema.json",
     "whats-new-panel": "schema/whats-new-panel.schema.json",
-    "action": "schema/messaging-system-special-message-actions.schema.json"
+    "action": "schema/messaging-system-special-message-actions.schema.json",
+    "message-groups": "schema/message-groups.schema.json",
 }
 
 USAGE = """


### PR DESCRIPTION
Follow up to bug 1640734:
We previously had turned off the `groups` provider that was trying to fetch from an empty RS bucket.
Now we had to re-enable it, we are going to use groups for different frequency capping for production CFRs and experiment CFRs while at the same time having both groups reference the same user preferences.
I'm publishing a simple message with no restrictions (frequency or user prefs) to prevent errors from showing up again in Firefox (empty bucket) but also to have the schema and checks in place for when we will eventually ship actual configurations.