### PR TITLE
Bug 1645043 - Allow wrapping between "and more" for narrow width

### DIFF
--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -325,7 +325,7 @@
                 "id": "AW_IMPORT_SETTINGS",
                 "order": 1,
                 "content": {
-                  "title": "Import your passwords, bookmarks,\u00a0and\u00a0more",
+                  "title": "Import your passwords, bookmarks,\u00a0and more",
                   "subtitle": "Coming from another browser? It's easy to bring everything to Firefox.",
                   "tiles": true,
                   "primary_button": {
@@ -389,7 +389,7 @@
                 "id": "AW_IMPORT_SETTINGS",
                 "order": 1,
                 "content": {
-                  "title": "Import your passwords, bookmarks,\u00a0and\u00a0more",
+                  "title": "Import your passwords, bookmarks,\u00a0and more",
                   "subtitle": "Coming from another browser? It's easy to bring everything to Firefox.",
                   "tiles": true,
                   "primary_button": {

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -213,7 +213,7 @@
             - id: "AW_IMPORT_SETTINGS"
               order: 1
               content:
-                title: Import your passwords, bookmarks, and more
+                title: Import your passwords, bookmarks, and more
                 subtitle: Coming from another browser? It's easy to bring everything to Firefox.
                 tiles: true
                 primary_button:
@@ -256,7 +256,7 @@
             - id: "AW_IMPORT_SETTINGS"
               order: 1
               content:
-                title: Import your passwords, bookmarks, and more
+                title: Import your passwords, bookmarks, and more
                 subtitle: Coming from another browser? It's easy to bring everything to Firefox.
                 tiles: true
                 primary_button:


### PR DESCRIPTION
r? @punamdahiya Use the non-breaking space only between "bookmarks, and"

Before:
<img width="523" alt="before narrow" src="https://user-images.githubusercontent.com/438537/84418196-a8fbb380-abcb-11ea-9cb1-986a771a1319.png">
<img width="612" alt="before after wide" src="https://user-images.githubusercontent.com/438537/84418202-ab5e0d80-abcb-11ea-8fea-9d25f015c65c.png">

After:
<img width="425" alt="after narrow" src="https://user-images.githubusercontent.com/438537/84418213-aef19480-abcb-11ea-81e1-e6b0cc00be5e.png">
<img width="612" alt="before after wide" src="https://user-images.githubusercontent.com/438537/84418202-ab5e0d80-abcb-11ea-8fea-9d25f015c65c.png">