### PR TITLE
Bug 1646286 - Allow Toolbar messages to specify how to open about pages

### DIFF
--- a/schema/whats-new-panel.schema.json
+++ b/schema/whats-new-panel.schema.json
@@ -80,6 +80,10 @@
         "cta_url": {
           "$ref": "#/definitions/linkUrl"
         },
+        "cta_where": {
+          "description": "How to open the cta: new window, tab, focused, unfocused.",
+          "enum": ["current", "tabshifted", "tab", "save", "window"]
+        },
         "icon_url": {
           "anyOf": [
             {

--- a/whats-new-panel.json
+++ b/whats-new-panel.json
@@ -143,8 +143,8 @@
       "body": {
         "string_id": "cfr-whatsnew-protections-body"
       },
-      "cta_url": "protections",
-      "cta_type": "OPEN_ABOUT_PAGE",
+      "cta_url": "",
+      "cta_type": "OPEN_PROTECTION_REPORT",
       "link_text": {
         "string_id": "cfr-whatsnew-protections-cta-link"
       }

--- a/whats-new-panel.yaml
+++ b/whats-new-panel.yaml
@@ -108,8 +108,8 @@
       string_id: cfr-whatsnew-protections-icon-alt
     body:
       string_id: cfr-whatsnew-protections-body
-    cta_url: protections
-    cta_type: OPEN_ABOUT_PAGE
+    cta_url: ""
+    cta_type: OPEN_PROTECTION_REPORT
     link_text:
       string_id: cfr-whatsnew-protections-cta-link
   targeting: firefoxVersion >= 78


### PR DESCRIPTION
Current 78 message would open protections report in the background (not focused)
* Updated the curent 78 message to use `OPEN_PROTECTION_REPORT`
* Added to schema that wnp messages can specify ho to open about pages (would default to `tabshifted` -> unfocused)