### PR TITLE
Fix escaping, add https pattern matches

### DIFF
--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -348,7 +348,8 @@
             "trigger": {
               "id": "frequentVisits",
               "patterns": [
-                "http://*/*"
+                "http://*/*",
+                "https://*/*"
               ]
             }
           }
@@ -415,7 +416,8 @@
             "trigger": {
               "id": "frequentVisits",
               "patterns": [
-                "http://*/*"
+                "http://*/*",
+                "https://*/*"
               ]
             }
           }
@@ -486,7 +488,8 @@
             "trigger": {
               "id": "frequentVisits",
               "patterns": [
-                "http://*/*"
+                "http://*/*",
+                "https://*/*"
               ]
             }
           }

--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -266,7 +266,7 @@
     "id": "PROTECTION-RETENTION-EXPERIMENT-RELEASE",
     "enabled": true,
     "filter_expression": "env.channel == 'nightly' || env.channel == 'default'",
-    "targeting": "localeLanguageCode == 'en' && [userId, \"PROTECTION-RETENTION-EXPERIMENT-RELEASE\"]|stableSample(0.1)",
+    "targeting": "localeLanguageCode == 'en' && [userId, \"PROTECTION-RETENTION-EXPERIMENT-RELEASE\"]|stableSample(0.1) && 'app.shield.optoutstudies.enabled'|preferenceValue",
     "arguments": {
       "slug": "bug-1645918-high-velocity-message-testing-privacy-retention-study",
       "userFacingName": "Message Router Content Experiment High Velocity Message Testing Privacy Retention Study",

--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -265,8 +265,8 @@
   {
     "id": "PROTECTION-RETENTION-EXPERIMENT-RELEASE",
     "enabled": true,
-    "filter_expression": "env.channel == 'nightly' || env.channel == 'default'",
-    "targeting": "localeLanguageCode == 'en' && [userId, \"PROTECTION-RETENTION-EXPERIMENT-RELEASE\"]|stableSample(0.1) && 'app.shield.optoutstudies.enabled'|preferenceValue",
+    "filter_expression": "(env.channel == 'release' || env.channel == 'default') && env.version >= '77.'",
+    "targeting": "localeLanguageCode == 'en' && [userId, \"messaging-experiments-cfr\"]|bucketSample(0, 310, 10000) && 'app.shield.optoutstudies.enabled'|preferenceValue",
     "arguments": {
       "slug": "bug-1645918-high-velocity-message-testing-privacy-retention-study",
       "userFacingName": "Message Router Content Experiment High Velocity Message Testing Privacy Retention Study",

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -200,7 +200,7 @@
               label:
                 string_id: cfr-doorhanger-extension-sumo-link
               sumo_path: extensionrecommendations
-            text: 'You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.'
+            text: You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.
             icon: chrome://browser/content/logos/tracking-protection.svg
             icon_dark_theme: chrome://browser/content/logos/tracking-protection-dark-theme.svg
             buttons:
@@ -248,7 +248,7 @@
               label:
                 string_id: cfr-doorhanger-extension-sumo-link
               sumo_path: extensionrecommendations
-            text: 'You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.'
+            text: You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.
             icon: chrome://browser/content/logos/tracking-protection.svg
             icon_dark_theme: chrome://browser/content/logos/tracking-protection-dark-theme.svg
             buttons:
@@ -293,7 +293,7 @@
               label:
                 string_id: cfr-doorhanger-extension-sumo-link
               sumo_path: extensionrecommendations
-            text: 'You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.'
+            text: You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.
             icon: chrome://browser/content/logos/tracking-protection.svg
             icon_dark_theme: chrome://browser/content/logos/tracking-protection-dark-theme.svg
             buttons:

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -200,7 +200,7 @@
               label:
                 string_id: cfr-doorhanger-extension-sumo-link
               sumo_path: extensionrecommendations
-            text: You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.
+            text: 'You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.'
             icon: chrome://browser/content/logos/tracking-protection.svg
             icon_dark_theme: chrome://browser/content/logos/tracking-protection-dark-theme.svg
             buttons:
@@ -228,6 +228,7 @@
             id: frequentVisits
             patterns:
               - http://*/*
+              - https://*/*
       - slug: treatment-variation-b
         ratio: 1
         groups:
@@ -247,7 +248,7 @@
               label:
                 string_id: cfr-doorhanger-extension-sumo-link
               sumo_path: extensionrecommendations
-            text: You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.
+            text: 'You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.'
             icon: chrome://browser/content/logos/tracking-protection.svg
             icon_dark_theme: chrome://browser/content/logos/tracking-protection-dark-theme.svg
             buttons:
@@ -272,6 +273,7 @@
             id: frequentVisits
             patterns:
               - http://*/*
+              - https://*/*
       - slug: treatment-variation-c
         ratio: 1
         groups:
@@ -291,7 +293,7 @@
               label:
                 string_id: cfr-doorhanger-extension-sumo-link
               sumo_path: extensionrecommendations
-            text: You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.
+            text: 'You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.'
             icon: chrome://browser/content/logos/tracking-protection.svg
             icon_dark_theme: chrome://browser/content/logos/tracking-protection-dark-theme.svg
             buttons:
@@ -319,6 +321,7 @@
             id: frequentVisits
             patterns:
               - http://*/*
+              - https://*/*
 - id: MULTI-STAGE-ABOUTWELCOME-V1-78-RELEASE
   enabled: true
   filter_expression: env.version >= '78.' && env.version < '79.' && env.channel == 'release'

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -167,8 +167,8 @@
                     type: OPEN_PRIVATE_BROWSER_WINDOW
 - id: "PROTECTION-RETENTION-EXPERIMENT-RELEASE"
   enabled: true
-  filter_expression: env.channel == 'nightly' || env.channel == 'default'
-  targeting: localeLanguageCode == 'en' && [userId, "PROTECTION-RETENTION-EXPERIMENT-RELEASE"]|stableSample(0.1) && 'app.shield.optoutstudies.enabled'|preferenceValue
+  filter_expression: (env.channel == 'release' || env.channel == 'default') && env.version >= '77.'
+  targeting: localeLanguageCode == 'en' && [userId, "messaging-experiments-cfr"]|bucketSample(0, 310, 10000) && 'app.shield.optoutstudies.enabled'|preferenceValue
   arguments:
     slug: bug-1645918-high-velocity-message-testing-privacy-retention-study
     userFacingName: Message Router Content Experiment High Velocity Message Testing Privacy Retention Study

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -168,7 +168,7 @@
 - id: "PROTECTION-RETENTION-EXPERIMENT-RELEASE"
   enabled: true
   filter_expression: env.channel == 'nightly' || env.channel == 'default'
-  targeting: localeLanguageCode == 'en' && [userId, "PROTECTION-RETENTION-EXPERIMENT-RELEASE"]|stableSample(0.1)
+  targeting: localeLanguageCode == 'en' && [userId, "PROTECTION-RETENTION-EXPERIMENT-RELEASE"]|stableSample(0.1) && 'app.shield.optoutstudies.enabled'|preferenceValue
   arguments:
     slug: bug-1645918-high-velocity-message-testing-privacy-retention-study
     userFacingName: Message Router Content Experiment High Velocity Message Testing Privacy Retention Study


### PR DESCRIPTION
So bizarre: the escaping issue is not showing up in the diff :/ if this still doesn't work I will manually fix it when deploying to RS.
Also added match for `https` and not enrolling if users specified that in their preferences.

Details: https://docs.google.com/document/d/1-6yFzp3iQKbaeQl624O3a8GN3DGz7eg4rvQI18BS1nE/edit#heading=h.e871marbqms9