### PR TITLE
Add message group for CFR and experiment

### DIFF
--- a/message-groups.json
+++ b/message-groups.json
@@ -1,7 +1,19 @@
 [
   {
-    "id": "messaging-experiments",
+    "id": "cfr",
     "enabled": true,
-    "type": "remote-settings"
+    "type": "remote-settings",
+    "userPreferences": [
+      "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons",
+      "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features"
+    ],
+    "frequency": {
+      "custom": [
+        {
+          "period": "daily",
+          "cap": 1
+        }
+      ]
+    }
   }
 ]

--- a/message-groups.yaml
+++ b/message-groups.yaml
@@ -1,3 +1,9 @@
-- id: messaging-experiments
+- id: cfr
   enabled: true
-  type: "remote-settings"
+  type: remote-settings
+  userPreferences:
+    - browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons
+    - browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features
+  frequency:
+    custom:
+      - {period: daily, cap: 1}

--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -291,6 +291,9 @@
           "value": {
             "id": "PROTECTIONS_RETENTION_PRIVACY",
             "template": "cfr_doorhanger",
+            "groups": [
+              "cfr"
+            ],
             "content": {
               "layout": "icon_and_message",
               "category": "cfrFeatures",
@@ -369,6 +372,9 @@
           "value": {
             "id": "PROTECTIONS_RETENTION_PROTECTIONS",
             "template": "cfr_doorhanger",
+            "groups": [
+              "cfr"
+            ],
             "content": {
               "layout": "icon_and_message",
               "category": "cfrFeatures",
@@ -443,6 +449,9 @@
           "value": {
             "id": "PROTECTIONS_RETENTION_MONITOR",
             "template": "cfr_doorhanger",
+            "groups": [
+              "cfr"
+            ],
             "content": {
               "layout": "icon_and_message",
               "category": "cfrFeatures",

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -188,6 +188,7 @@
         value:
           id: PROTECTIONS_RETENTION_PRIVACY
           template: cfr_doorhanger
+          groups: [cfr]
           content:
             layout: icon_and_message
             category: cfrFeatures
@@ -237,6 +238,7 @@
         value:
           id: PROTECTIONS_RETENTION_PROTECTIONS
           template: cfr_doorhanger
+          groups: [cfr]
           content:
             layout: icon_and_message
             category: cfrFeatures
@@ -283,6 +285,7 @@
         value:
           id: PROTECTIONS_RETENTION_MONITOR
           template: cfr_doorhanger
+          groups: [cfr]
           content:
             layout: icon_and_message
             category: cfrFeatures

--- a/schema/cfr.schema.json
+++ b/schema/cfr.schema.json
@@ -19,6 +19,14 @@
       "type": "string",
       "description": "Message identifier"
     },
+    "groups": {
+      "description": "Array of preferences used to control `enabled` status of the group. If any is `false` the group is disabled.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Preference name"
+      }
+    },
     "content": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
I've added a group configuration that matches the current CFR config (via pref `browser.newtabpage.activity-stream.asrouter.providers.cfr`)
```
// 1 per day, if those 2 prefs are enabled
"frequency":{"custom":[{"period":"daily","cap":1}]},"categories":["cfrAddons","cfrFeatures"],
```
But moved to group config so that we can share it with Experiment CFR Messages.
And added it to the current experiment.
This also fixes an issue: if users disabled CFRs they should not see the experiment messages.