### PR TITLE
Add new groups for moments and cfr-experiments

### DIFF
--- a/message-groups.json
+++ b/message-groups.json
@@ -15,5 +15,30 @@
         }
       ]
     }
+  },
+  {
+    "id": "cfr-experiments",
+    "enabled": true,
+    "type": "remote-settings",
+    "userPreferences": [
+      "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons",
+      "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features"
+    ],
+    "frequency": {
+      "custom": [
+        {
+          "period": 86400000,
+          "cap": 1
+        }
+      ]
+    }
+  },
+  {
+    "id": "moments-pages",
+    "enabled": true,
+    "type": "remote-settings",
+    "userPreferences": [
+      "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features"
+    ]
   }
 ]

--- a/message-groups.yaml
+++ b/message-groups.yaml
@@ -7,3 +7,17 @@
   frequency:
     custom:
       - {period: 86400000, cap: 1}
+- id: cfr-experiments
+  enabled: true
+  type: remote-settings
+  userPreferences:
+    - browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons
+    - browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features
+  frequency:
+    custom:
+      - {period: 86400000, cap: 1}
+- id: moments-pages
+  enabled: true
+  type: remote-settings
+  userPreferences:
+    - browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features

--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -702,6 +702,9 @@
           ],
           "value": {
             "id": "XMAN_MOMENTS_TEST",
+            "groups": [
+              "moments-pages"
+            ],
             "content": {
               "action": {
                 "data": {

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -455,6 +455,7 @@
           - moments-page
         value:
           id: XMAN_MOMENTS_TEST
+          groups: [moments-pages]
           content:
             action:
               data:

--- a/moments.json
+++ b/moments.json
@@ -1,6 +1,9 @@
 [
   {
     "id": "WNP_MOMENTS_8",
+    "groups": [
+      "moments-pages"
+    ],
     "content": {
       "action": {
         "data": {
@@ -19,6 +22,9 @@
   },
   {
     "id": "WNP_MOMENTS_2",
+    "groups": [
+      "moments-pages"
+    ],
     "content": {
       "action": {
         "data": {
@@ -37,6 +43,9 @@
   },
   {
     "id": "WNP_MOMENTS_1",
+    "groups": [
+      "moments-pages"
+    ],
     "content": {
       "action": {
         "data": {

--- a/moments.yaml
+++ b/moments.yaml
@@ -1,4 +1,5 @@
 - id: WNP_MOMENTS_8
+  groups: [moments-pages]
   content:
     action:
       data:
@@ -17,6 +18,7 @@
   trigger:
     id: momentsUpdate
 - id: WNP_MOMENTS_2
+  groups: [moments-pages]
   content:
     action:
       data:
@@ -31,6 +33,7 @@
   trigger:
     id: momentsUpdate
 - id: WNP_MOMENTS_1
+  groups: [moments-pages]
   content:
     action:
       data:

--- a/schema/moments-action.schema.json
+++ b/schema/moments-action.schema.json
@@ -4,6 +4,14 @@
   "version": "1.0.0",
   "type": "object",
   "properties": {
+    "groups": {
+      "type": "array",
+      "description": "Configure message behaviour: frequency, prefs",
+      "items": {
+        "type": "string",
+        "description": "Name of group configuration"
+      }
+    },
     "content": {
       "type": "object",
       "properties": {
@@ -46,5 +54,6 @@
       "additionalProperties": false,
       "required": ["action", "bucket_id"]
     }
-  }
+  },
+  "required": ["groups", "content"]
 }

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -152,7 +152,9 @@ def get_branch_message(branch):
         else:
             return "onboarding", None
     elif branch["groups"] == ["moments-page"]:
-        return "moments-page", branch["value"]
+        if "id" in branch["value"]:
+            return "moments-page", branch["value"]
+        return "moments-page", None
     else:
         return None, None
 


### PR DESCRIPTION
Two different changes here:
* for the containers and protection CFR experiments we grouped messages under the same group configuration (`cfr`). This allowed to share user preferences and frequency caps. Unfortunately sharing the same frequency cap was not desired so we need a copy of the `cfr` group, `cfr-experiments`, so that the two have separate daily freq caps (essentially be able to see a production and an experiment CFR without worrying about interactions).
* Allow users to block moments pages by turning off features in about:preferences. 