### PR TITLE
Deploy Privacy Retention v2 Experiment

### DIFF
--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -1395,25 +1395,17 @@
   {
     "id": "PRIVACY-RETENTION-STUDY-V2-BUG-1656311",
     "enabled": true,
-    "filter_expression": "(env.channel == 'release' || env.channel == 'default') && env.version >= '79.'",
-    "targeting": "localeLanguageCode == 'en' && 'app.shield.optoutstudies.enabled'|preferenceValue && ((currentDate|date - profileAgeCreated) / 86400000) <= 14",
+    "filter_expression": "env.channel == 'release' && env.version >= '79.'",
+    "targeting": "localeLanguageCode == 'en' && [userId, \"messaging-experiments-cfr\"]|bucketSample(311, 5311, 10000) && 'app.shield.optoutstudies.enabled'|preferenceValue && ((currentDate|date - profileAgeCreated) / 86400000) <= 14",
     "arguments": {
-      "slug": "bug-1656311-message-high-velocity-message-testing-privacy-retenti-release-79-v2",
+      "slug": "bug-1656311-message-high-velocity-message-testing-privacy-retenti-release-79-80",
       "userFacingName": "Message Router Content Experiment High Velocity Message Testing Privacy Retention Study V2",
       "experimentDocumentUrl": "https://experimenter.services.mozilla.com/experiments/high-velocity-message-testing-privacy-retention-study-v2/",
-      "userFacingDescription": "This measures retention changes across some privacy pages including the Protections Dashboard, Mozilla's Privacy Promise, and Firefox Monitor.",
+      "userFacingDescription": "This measures retention changes across some privacy pages including the Protections Dashboard, and Mozilla's Privacy Promise.",
       "isEnrollmentPaused": false,
       "branches": [
         {
-          "slug": "control",
-          "ratio": 1,
-          "groups": [
-            "cfr"
-          ],
-          "value": {}
-        },
-        {
-          "slug": "treatment-variation-a",
+          "slug": "cfr-to-privacy-promise",
           "ratio": 1,
           "groups": [
             "cfr"
@@ -1450,7 +1442,7 @@
                   "action": {
                     "type": "OPEN_URL",
                     "data": {
-                      "args": "https://www.mozilla.org/firefox/privacy/?utm_source=firefox-desktop&utm_campaign=hvt-privacy-retention&utm_medium=referral",
+                      "args": "https://www.mozilla.org/firefox/privacy/?utm_source=firefox-desktop&utm_campaign=hvt-privacy-retention-v2&utm_medium=referral",
                       "where": "tab"
                     }
                   }
@@ -1492,7 +1484,7 @@
           }
         },
         {
-          "slug": "treatment-variation-b",
+          "slug": "cfr-to-protections-dashboard",
           "ratio": 1,
           "groups": [
             "cfr"
@@ -1528,85 +1520,6 @@
                   },
                   "action": {
                     "type": "OPEN_PROTECTION_REPORT"
-                  }
-                },
-                "secondary": [
-                  {
-                    "label": {
-                      "string_id": "cfr-doorhanger-extension-cancel-button"
-                    },
-                    "action": {
-                      "type": "CANCEL"
-                    }
-                  },
-                  {
-                    "label": {
-                      "string_id": "cfr-doorhanger-extension-never-show-recommendation"
-                    }
-                  }
-                ]
-              }
-            },
-            "frequency": {
-              "lifetime": 3,
-              "custom": [
-                {
-                  "period": 86400000,
-                  "cap": 1
-                }
-              ]
-            },
-            "targeting": "recentVisits|length > 1 && userPrefs.cfrFeatures",
-            "trigger": {
-              "id": "frequentVisits",
-              "patterns": [
-                "http://*/*",
-                "https://*/*"
-              ]
-            }
-          }
-        },
-        {
-          "slug": "treatment-variation-c",
-          "ratio": 1,
-          "groups": [
-            "cfr"
-          ],
-          "value": {
-            "id": "PRIVACY_RETENTION_MONITOR",
-            "template": "cfr_doorhanger",
-            "content": {
-              "layout": "icon_and_message",
-              "category": "cfrFeatures",
-              "anchor_id": "tracking-protection-icon-box",
-              "skip_address_bar_notifier": true,
-              "persistent_doorhanger": true,
-              "bucket_id": "PRIVACY_RETENTION_MONITOR",
-              "heading_text": "Putting your privacy before profits",
-              "notification_text": "",
-              "info_icon": {
-                "label": {
-                  "string_id": "cfr-doorhanger-extension-sumo-link"
-                },
-                "sumo_path": "extensionrecommendations"
-              },
-              "text": "You\u2019re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.",
-              "icon": "chrome://browser/content/logos/tracking-protection.svg",
-              "icon_dark_theme": "chrome://browser/content/logos/tracking-protection-dark-theme.svg",
-              "buttons": {
-                "primary": {
-                  "label": {
-                    "value": "Show Me",
-                    "attributes": {
-                      "accesskey": "S"
-                    }
-                  },
-                  "action": {
-                    "type": "OPEN_URL",
-                    "data": {
-                      "args": "https://monitor.firefox.com/about?utm_source=firefox-desktop&utm_campaign=hvt-privacy-retention&utm_medium=referral",
-                      "where": "tab"
-                    }
                   }
                 },
                 "secondary": [

--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -1391,5 +1391,261 @@
         }
       ]
     }
+  },
+  {
+    "id": "PRIVACY-RETENTION-STUDY-V2-BUG-1656311",
+    "enabled": true,
+    "filter_expression": "(env.channel == 'release' || env.channel == 'default') && env.version >= '79.'",
+    "targeting": "localeLanguageCode == 'en' && 'app.shield.optoutstudies.enabled'|preferenceValue",
+    "arguments": {
+      "slug": "bug-1656311-message-high-velocity-message-testing-privacy-retenti-release-79-v2",
+      "userFacingName": "Message Router Content Experiment High Velocity Message Testing Privacy Retention Study V2",
+      "experimentDocumentUrl": "https://experimenter.services.mozilla.com/experiments/high-velocity-message-testing-privacy-retention-study-v2/",
+      "userFacingDescription": "This measures retention changes across some privacy pages including the Protections Dashboard, Mozilla's Privacy Promise, and Firefox Monitor.",
+      "isEnrollmentPaused": false,
+      "branches": [
+        {
+          "slug": "control",
+          "ratio": 1,
+          "groups": [
+            "cfr"
+          ],
+          "value": {}
+        },
+        {
+          "slug": "treatment-variation-a",
+          "ratio": 1,
+          "groups": [
+            "cfr"
+          ],
+          "value": {
+            "id": "PRIVACY_RETENTION_PRIVACY",
+            "template": "cfr_doorhanger",
+            "content": {
+              "layout": "icon_and_message",
+              "category": "cfrFeatures",
+              "anchor_id": "tracking-protection-icon-box",
+              "skip_address_bar_notifier": true,
+              "persistent_doorhanger": true,
+              "bucket_id": "PRIVACY_RETENTION_PRIVACY",
+              "heading_text": "Putting your privacy before profits",
+              "notification_text": "",
+              "info_icon": {
+                "label": {
+                  "string_id": "cfr-doorhanger-extension-sumo-link"
+                },
+                "sumo_path": "extensionrecommendations"
+              },
+              "text": "You\u2019re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.",
+              "icon": "chrome://browser/content/logos/tracking-protection.svg",
+              "icon_dark_theme": "chrome://browser/content/logos/tracking-protection-dark-theme.svg",
+              "buttons": {
+                "primary": {
+                  "label": {
+                    "value": "Show Me",
+                    "attributes": {
+                      "accesskey": "S"
+                    }
+                  },
+                  "action": {
+                    "type": "OPEN_URL",
+                    "data": {
+                      "args": "https://www.mozilla.org/firefox/privacy/?utm_source=firefox-desktop&utm_campaign=hvt-privacy-retention&utm_medium=referral",
+                      "where": "tab"
+                    }
+                  }
+                },
+                "secondary": [
+                  {
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-cancel-button"
+                    },
+                    "action": {
+                      "type": "CANCEL"
+                    }
+                  },
+                  {
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+                    }
+                  }
+                ]
+              }
+            },
+            "targeting": "recentVisits|length > 1 && userPrefs.cfrFeatures",
+            "frequency": {
+              "lifetime": 3,
+              "custom": [
+                {
+                  "period": 86400000,
+                  "cap": 1
+                }
+              ]
+            },
+            "trigger": {
+              "id": "frequentVisits",
+              "patterns": [
+                "http://*/*",
+                "https://*/*"
+              ]
+            }
+          }
+        },
+        {
+          "slug": "treatment-variation-b",
+          "ratio": 1,
+          "groups": [
+            "cfr"
+          ],
+          "value": {
+            "id": "PRIVACY_RETENTION_PROTECTION_REPORT",
+            "template": "cfr_doorhanger",
+            "content": {
+              "layout": "icon_and_message",
+              "category": "cfrFeatures",
+              "anchor_id": "tracking-protection-icon-box",
+              "skip_address_bar_notifier": true,
+              "persistent_doorhanger": true,
+              "bucket_id": "PRIVACY_RETENTION_PROTECTION_REPORT",
+              "heading_text": "Putting your privacy before profits",
+              "notification_text": "",
+              "info_icon": {
+                "label": {
+                  "string_id": "cfr-doorhanger-extension-sumo-link"
+                },
+                "sumo_path": "extensionrecommendations"
+              },
+              "text": "You\u2019re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.",
+              "icon": "chrome://browser/content/logos/tracking-protection.svg",
+              "icon_dark_theme": "chrome://browser/content/logos/tracking-protection-dark-theme.svg",
+              "buttons": {
+                "primary": {
+                  "label": {
+                    "value": "Show Me",
+                    "attributes": {
+                      "accesskey": "S"
+                    }
+                  },
+                  "action": {
+                    "type": "OPEN_PROTECTION_REPORT"
+                  }
+                },
+                "secondary": [
+                  {
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-cancel-button"
+                    },
+                    "action": {
+                      "type": "CANCEL"
+                    }
+                  },
+                  {
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+                    }
+                  }
+                ]
+              }
+            },
+            "frequency": {
+              "lifetime": 3,
+              "custom": [
+                {
+                  "period": 86400000,
+                  "cap": 1
+                }
+              ]
+            },
+            "targeting": "recentVisits|length > 1 && userPrefs.cfrFeatures",
+            "trigger": {
+              "id": "frequentVisits",
+              "patterns": [
+                "http://*/*",
+                "https://*/*"
+              ]
+            }
+          }
+        },
+        {
+          "slug": "treatment-variation-c",
+          "ratio": 1,
+          "groups": [
+            "cfr"
+          ],
+          "value": {
+            "id": "PRIVACY_RETENTION_MONITOR",
+            "template": "cfr_doorhanger",
+            "content": {
+              "layout": "icon_and_message",
+              "category": "cfrFeatures",
+              "anchor_id": "tracking-protection-icon-box",
+              "skip_address_bar_notifier": true,
+              "persistent_doorhanger": true,
+              "bucket_id": "PRIVACY_RETENTION_MONITOR",
+              "heading_text": "Putting your privacy before profits",
+              "notification_text": "",
+              "info_icon": {
+                "label": {
+                  "string_id": "cfr-doorhanger-extension-sumo-link"
+                },
+                "sumo_path": "extensionrecommendations"
+              },
+              "text": "You\u2019re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.",
+              "icon": "chrome://browser/content/logos/tracking-protection.svg",
+              "icon_dark_theme": "chrome://browser/content/logos/tracking-protection-dark-theme.svg",
+              "buttons": {
+                "primary": {
+                  "label": {
+                    "value": "Show Me",
+                    "attributes": {
+                      "accesskey": "S"
+                    }
+                  },
+                  "action": {
+                    "type": "OPEN_URL",
+                    "data": {
+                      "args": "https://monitor.firefox.com/about?utm_source=firefox-desktop&utm_campaign=hvt-privacy-retention&utm_medium=referral",
+                      "where": "tab"
+                    }
+                  }
+                },
+                "secondary": [
+                  {
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-cancel-button"
+                    },
+                    "action": {
+                      "type": "CANCEL"
+                    }
+                  },
+                  {
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+                    }
+                  }
+                ]
+              }
+            },
+            "frequency": {
+              "lifetime": 3,
+              "custom": [
+                {
+                  "period": 86400000,
+                  "cap": 1
+                }
+              ]
+            },
+            "targeting": "recentVisits|length > 1 && userPrefs.cfrFeatures",
+            "trigger": {
+              "id": "frequentVisits",
+              "patterns": [
+                "http://*/*",
+                "https://*/*"
+              ]
+            }
+          }
+        }
+      ]
+    }
   }
 ]

--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -1396,7 +1396,7 @@
     "id": "PRIVACY-RETENTION-STUDY-V2-BUG-1656311",
     "enabled": true,
     "filter_expression": "(env.channel == 'release' || env.channel == 'default') && env.version >= '79.'",
-    "targeting": "localeLanguageCode == 'en' && 'app.shield.optoutstudies.enabled'|preferenceValue",
+    "targeting": "localeLanguageCode == 'en' && 'app.shield.optoutstudies.enabled'|preferenceValue && ((currentDate|date - profileAgeCreated) / 86400000) <= 14",
     "arguments": {
       "slug": "bug-1656311-message-high-velocity-message-testing-privacy-retenti-release-79-v2",
       "userFacingName": "Message Router Content Experiment High Velocity Message Testing Privacy Retention Study V2",

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -947,7 +947,7 @@
   enabled: true
   filter_expression: (env.channel == 'release' || env.channel == 'default') && env.version >= '79.'
   # && [userId, "messaging-experiments-cfr"]|bucketSample(311, 871, 10000)
-  targeting: localeLanguageCode == 'en' && 'app.shield.optoutstudies.enabled'|preferenceValue
+  targeting: localeLanguageCode == 'en' && 'app.shield.optoutstudies.enabled'|preferenceValue && ((currentDate|date - profileAgeCreated) / 86400000) <= 14
   arguments:
     slug: bug-1656311-message-high-velocity-message-testing-privacy-retenti-release-79-v2
     userFacingName: Message Router Content Experiment High Velocity Message Testing Privacy Retention Study V2

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -943,3 +943,167 @@
                   action:
                     navigate: true
                     theme: default
+- id: "PRIVACY-RETENTION-STUDY-V2-BUG-1656311"
+  enabled: true
+  filter_expression: (env.channel == 'release' || env.channel == 'default') && env.version >= '79.'
+  # && [userId, "messaging-experiments-cfr"]|bucketSample(311, 871, 10000)
+  targeting: localeLanguageCode == 'en' && 'app.shield.optoutstudies.enabled'|preferenceValue
+  arguments:
+    slug: bug-1656311-message-high-velocity-message-testing-privacy-retenti-release-79-v2
+    userFacingName: Message Router Content Experiment High Velocity Message Testing Privacy Retention Study V2
+    experimentDocumentUrl: https://experimenter.services.mozilla.com/experiments/high-velocity-message-testing-privacy-retention-study-v2/
+    userFacingDescription: This measures retention changes across some privacy pages including the Protections Dashboard, Mozilla's Privacy Promise, and Firefox Monitor.
+    isEnrollmentPaused: false
+    branches:
+      - slug: control
+        ratio: 1
+        groups:
+          - cfr
+        value: {}
+      - slug: treatment-variation-a
+        ratio: 1
+        groups:
+          - cfr
+        value:
+          id: PRIVACY_RETENTION_PRIVACY
+          template: cfr_doorhanger
+          content:
+            layout: icon_and_message
+            category: cfrFeatures
+            anchor_id: tracking-protection-icon-box
+            skip_address_bar_notifier: true
+            persistent_doorhanger: true
+            bucket_id: PRIVACY_RETENTION_PRIVACY
+            heading_text: Putting your privacy before profits
+            notification_text: ''
+            info_icon:
+              label:
+                string_id: cfr-doorhanger-extension-sumo-link
+              sumo_path: extensionrecommendations
+            text: You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.
+            icon: chrome://browser/content/logos/tracking-protection.svg
+            icon_dark_theme: chrome://browser/content/logos/tracking-protection-dark-theme.svg
+            buttons:
+              primary:
+                label:
+                  value: Show Me
+                  attributes:
+                    accesskey: S
+                action:
+                  type: OPEN_URL
+                  data:
+                    args: https://www.mozilla.org/firefox/privacy/?utm_source=firefox-desktop&utm_campaign=hvt-privacy-retention&utm_medium=referral
+                    where: tab
+              secondary:
+                - label:
+                    string_id: cfr-doorhanger-extension-cancel-button
+                  action:
+                    type: CANCEL
+                - label:
+                    string_id: cfr-doorhanger-extension-never-show-recommendation
+          targeting: recentVisits|length > 1 && userPrefs.cfrFeatures
+          frequency:
+            lifetime: 3
+            custom: [{period: 86400000, cap: 1}]
+          trigger:
+            id: frequentVisits
+            patterns:
+              - http://*/*
+              - https://*/*
+      - slug: treatment-variation-b
+        ratio: 1
+        groups:
+          - cfr
+        value:
+          id: PRIVACY_RETENTION_PROTECTION_REPORT
+          template: cfr_doorhanger
+          content:
+            layout: icon_and_message
+            category: cfrFeatures
+            anchor_id: tracking-protection-icon-box
+            skip_address_bar_notifier: true
+            persistent_doorhanger: true
+            bucket_id: PRIVACY_RETENTION_PROTECTION_REPORT
+            heading_text: Putting your privacy before profits
+            notification_text: ''
+            info_icon:
+              label:
+                string_id: cfr-doorhanger-extension-sumo-link
+              sumo_path: extensionrecommendations
+            text: You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.
+            icon: chrome://browser/content/logos/tracking-protection.svg
+            icon_dark_theme: chrome://browser/content/logos/tracking-protection-dark-theme.svg
+            buttons:
+              primary:
+                label:
+                  value: Show Me
+                  attributes:
+                    accesskey: S
+                action:
+                  type: OPEN_PROTECTION_REPORT
+              secondary:
+                - label:
+                    string_id: cfr-doorhanger-extension-cancel-button
+                  action:
+                    type: CANCEL
+                - label:
+                    string_id: cfr-doorhanger-extension-never-show-recommendation
+          frequency:
+            lifetime: 3
+            custom: [{period: 86400000, cap: 1}]
+          targeting: recentVisits|length > 1 && userPrefs.cfrFeatures
+          trigger:
+            id: frequentVisits
+            patterns:
+              - http://*/*
+              - https://*/*
+      - slug: treatment-variation-c
+        ratio: 1
+        groups:
+          - cfr
+        value:
+          id: PRIVACY_RETENTION_MONITOR
+          template: cfr_doorhanger
+          content:
+            layout: icon_and_message
+            category: cfrFeatures
+            anchor_id: tracking-protection-icon-box
+            skip_address_bar_notifier: true
+            persistent_doorhanger: true
+            bucket_id: PRIVACY_RETENTION_MONITOR
+            heading_text: Putting your privacy before profits
+            notification_text: ''
+            info_icon:
+              label:
+                string_id: cfr-doorhanger-extension-sumo-link
+              sumo_path: extensionrecommendations
+            text: You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.
+            icon: chrome://browser/content/logos/tracking-protection.svg
+            icon_dark_theme: chrome://browser/content/logos/tracking-protection-dark-theme.svg
+            buttons:
+              primary:
+                label:
+                  value: Show Me
+                  attributes:
+                    accesskey: S
+                action:
+                  type: OPEN_URL
+                  data:
+                    args: https://monitor.firefox.com/about?utm_source=firefox-desktop&utm_campaign=hvt-privacy-retention&utm_medium=referral
+                    where: tab
+              secondary:
+                - label:
+                    string_id: cfr-doorhanger-extension-cancel-button
+                  action:
+                    type: CANCEL
+                - label:
+                    string_id: cfr-doorhanger-extension-never-show-recommendation
+          frequency:
+            lifetime: 3
+            custom: [{period: 86400000, cap: 1}]
+          targeting: recentVisits|length > 1 && userPrefs.cfrFeatures
+          trigger:
+            id: frequentVisits
+            patterns:
+              - http://*/*
+              - https://*/*

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -945,22 +945,17 @@
                     theme: default
 - id: "PRIVACY-RETENTION-STUDY-V2-BUG-1656311"
   enabled: true
-  filter_expression: (env.channel == 'release' || env.channel == 'default') && env.version >= '79.'
-  # && [userId, "messaging-experiments-cfr"]|bucketSample(311, 871, 10000)
-  targeting: localeLanguageCode == 'en' && 'app.shield.optoutstudies.enabled'|preferenceValue && ((currentDate|date - profileAgeCreated) / 86400000) <= 14
+  filter_expression: env.channel == 'release' && env.version >= '79.'
+  # 50% of release
+  targeting: localeLanguageCode == 'en' && [userId, "messaging-experiments-cfr"]|bucketSample(311, 5311, 10000) && 'app.shield.optoutstudies.enabled'|preferenceValue && ((currentDate|date - profileAgeCreated) / 86400000) <= 14
   arguments:
-    slug: bug-1656311-message-high-velocity-message-testing-privacy-retenti-release-79-v2
+    slug: bug-1656311-message-high-velocity-message-testing-privacy-retenti-release-79-80
     userFacingName: Message Router Content Experiment High Velocity Message Testing Privacy Retention Study V2
     experimentDocumentUrl: https://experimenter.services.mozilla.com/experiments/high-velocity-message-testing-privacy-retention-study-v2/
-    userFacingDescription: This measures retention changes across some privacy pages including the Protections Dashboard, Mozilla's Privacy Promise, and Firefox Monitor.
+    userFacingDescription: This measures retention changes across some privacy pages including the Protections Dashboard, and Mozilla's Privacy Promise.
     isEnrollmentPaused: false
     branches:
-      - slug: control
-        ratio: 1
-        groups:
-          - cfr
-        value: {}
-      - slug: treatment-variation-a
+      - slug: cfr-to-privacy-promise
         ratio: 1
         groups:
           - cfr
@@ -992,7 +987,7 @@
                 action:
                   type: OPEN_URL
                   data:
-                    args: https://www.mozilla.org/firefox/privacy/?utm_source=firefox-desktop&utm_campaign=hvt-privacy-retention&utm_medium=referral
+                    args: https://www.mozilla.org/firefox/privacy/?utm_source=firefox-desktop&utm_campaign=hvt-privacy-retention-v2&utm_medium=referral
                     where: tab
               secondary:
                 - label:
@@ -1010,7 +1005,7 @@
             patterns:
               - http://*/*
               - https://*/*
-      - slug: treatment-variation-b
+      - slug: cfr-to-protections-dashboard
         ratio: 1
         groups:
           - cfr
@@ -1041,56 +1036,6 @@
                     accesskey: S
                 action:
                   type: OPEN_PROTECTION_REPORT
-              secondary:
-                - label:
-                    string_id: cfr-doorhanger-extension-cancel-button
-                  action:
-                    type: CANCEL
-                - label:
-                    string_id: cfr-doorhanger-extension-never-show-recommendation
-          frequency:
-            lifetime: 3
-            custom: [{period: 86400000, cap: 1}]
-          targeting: recentVisits|length > 1 && userPrefs.cfrFeatures
-          trigger:
-            id: frequentVisits
-            patterns:
-              - http://*/*
-              - https://*/*
-      - slug: treatment-variation-c
-        ratio: 1
-        groups:
-          - cfr
-        value:
-          id: PRIVACY_RETENTION_MONITOR
-          template: cfr_doorhanger
-          content:
-            layout: icon_and_message
-            category: cfrFeatures
-            anchor_id: tracking-protection-icon-box
-            skip_address_bar_notifier: true
-            persistent_doorhanger: true
-            bucket_id: PRIVACY_RETENTION_MONITOR
-            heading_text: Putting your privacy before profits
-            notification_text: ''
-            info_icon:
-              label:
-                string_id: cfr-doorhanger-extension-sumo-link
-              sumo_path: extensionrecommendations
-            text: You’re using the only major browser backed by a non-profit. See how Firefox puts your privacy first.
-            icon: chrome://browser/content/logos/tracking-protection.svg
-            icon_dark_theme: chrome://browser/content/logos/tracking-protection-dark-theme.svg
-            buttons:
-              primary:
-                label:
-                  value: Show Me
-                  attributes:
-                    accesskey: S
-                action:
-                  type: OPEN_URL
-                  data:
-                    args: https://monitor.firefox.com/about?utm_source=firefox-desktop&utm_campaign=hvt-privacy-retention&utm_medium=referral
-                    where: tab
               secondary:
                 - label:
                     string_id: cfr-doorhanger-extension-cancel-button


### PR DESCRIPTION
> NOTE: Please ensure this experiment does not affect existing CFRs, Existing CFRs should be in their own bucket so that the experiment CFR and existing CFR can both show on the same day.

To do this I added a custom frequency per message and removed the `cfr` groups.
Also added the `persist_doorhanger` option along with `skip_address_bar_notifier` this way the message is not easily dismissed (because it is a direct doorhanger style, no "Recommendation" button in the urlbar).