### PR TITLE
Add PiP CFR experiment for 78

### DIFF
--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -1151,7 +1151,7 @@
     "id": "MESSAGE_ROUTER_PICTURE_IN_PICTURE_CFR",
     "enabled": true,
     "filter_expression": "env.channel == 'release' && env.version >= '78.' && env.version < '79.'",
-    "targeting": "locale == 'en-US' && userPrefs.cfrFeatures &&\n'media.videocontrols.picture-in-picture.enabled'|preferenceValue &&\n[userId, 'messaging-experiments-cfr']|bucketSample(5312, 650, 10000) &&\n((currentDate|date - profileAgeCreated) / 86400000) > 7\n",
+    "targeting": "locale == 'en-US' && userPrefs.cfrFeatures &&\n'media.videocontrols.picture-in-picture.enabled'|preferenceValue &&\n[userId, 'messaging-experiments-cfr']|bucketSample(5312, 650, 10000) &&\n((currentDate|date - profileAgeCreated) / 86400000) > 7 &&\n'app.shield.optoutstudies.enabled'|preferenceValue\n",
     "arguments": {
       "slug": "bug-1656382-message-recommend-picture-in-picture-cfr-release-77-80",
       "branches": [
@@ -1172,7 +1172,7 @@
           "value": {
             "id": "PIP_CFR_NEWS",
             "groups": [
-              "cfr"
+              "cfr-experiments"
             ],
             "content": {
               "bucket_id": "PIP_CFR_NEWS",
@@ -1238,7 +1238,7 @@
               "text": "Keep yourself in the loop. With Picture-in-Picture you can watch the latest news while you visit other websites or apps - hover over a video and select the blue icon."
             },
             "frequency": {
-              "lifetime": 30,
+              "lifetime": 3,
               "custom": [
                 {
                   "period": 86400000,
@@ -1291,7 +1291,7 @@
           "value": {
             "id": "PIP_CFR_SOCIAL_MEDIA",
             "groups": [
-              "cfr"
+              "cfr-experiments"
             ],
             "content": {
               "bucket_id": "PIP_CFR_SOCIAL_MEDIA",
@@ -1357,7 +1357,7 @@
               "text": "Wish you could watch videos shared by your friends and family as you browse the web? You can with Picture-in-Picture - hover over a video and select the blue icon."
             },
             "frequency": {
-              "lifetime": 30,
+              "lifetime": 3,
               "custom": [
                 {
                   "period": 86400000,
@@ -1390,7 +1390,7 @@
           "value": {
             "id": "PIP_CFR_ENTERTAINMENT",
             "groups": [
-              "cfr"
+              "cfr-experiments"
             ],
             "content": {
               "bucket_id": "PIP_CFR_ENTERTAINMENT",
@@ -1456,7 +1456,7 @@
               "text": "Binge watch your favorite shows guilt-free with Picture-in-Picture - hover over a video and select the blue icon."
             },
             "frequency": {
-              "lifetime": 30,
+              "lifetime": 3,
               "custom": [
                 {
                   "period": 86400000,
@@ -1494,7 +1494,7 @@
           "value": {
             "id": "PIP_CFR_INFORMATIONAL",
             "groups": [
-              "cfr"
+              "cfr-experiments"
             ],
             "content": {
               "bucket_id": "PIP_CFR_INFORMATIONAL",
@@ -1560,7 +1560,7 @@
               "text": "Picture-in-Picture lets you browse and watch videos at the same time - hover over a video and select the blue icon."
             },
             "frequency": {
-              "lifetime": 30,
+              "lifetime": 3,
               "custom": [
                 {
                   "period": 86400000,

--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -1150,10 +1150,10 @@
   {
     "id": "MESSAGE_ROUTER_PICTURE_IN_PICTURE_CFR",
     "enabled": true,
-    "filter_expression": "env.channel == 'release' && env.version >= '78.' && env.version < '79.'",
-    "targeting": "locale == 'en-US' && userPrefs.cfrFeatures &&\n'media.videocontrols.picture-in-picture.enabled'|preferenceValue &&\n[userId, 'messaging-experiments-cfr']|bucketSample(5312, 650, 10000) &&\n((currentDate|date - profileAgeCreated) / 86400000) > 7 &&\n'app.shield.optoutstudies.enabled'|preferenceValue\n",
+    "filter_expression": "env.channel == 'release' && env.version >= '78.' && env.version < '80.'",
+    "targeting": "locale == 'en-US' && userPrefs.cfrFeatures &&\nplatformName in [\"win\", \"macosx\"] &&\n'media.videocontrols.picture-in-picture.enabled'|preferenceValue &&\n[userId, 'messaging-experiments-cfr']|bucketSample(5312, 500, 10000) &&\n((currentDate|date - profileAgeCreated) / 86400000) > 7 &&\n'app.shield.optoutstudies.enabled'|preferenceValue\n",
     "arguments": {
-      "slug": "bug-1656382-message-recommend-picture-in-picture-cfr-release-77-80",
+      "slug": "bug-1658301-message-message-router-content-experiment-high-veloci-release-78-80",
       "branches": [
         {
           "slug": "control",
@@ -1164,7 +1164,7 @@
           ]
         },
         {
-          "slug": "treatment-a",
+          "slug": "treatment-a-news",
           "ratio": 1,
           "groups": [
             "cfr"
@@ -1283,7 +1283,7 @@
           }
         },
         {
-          "slug": "treatment-b",
+          "slug": "treatment-b-social-media",
           "ratio": 1,
           "groups": [
             "cfr"
@@ -1382,7 +1382,7 @@
           }
         },
         {
-          "slug": "treatment-c",
+          "slug": "treatment-c-entertainment",
           "ratio": 1,
           "groups": [
             "cfr"
@@ -1486,7 +1486,7 @@
           }
         },
         {
-          "slug": "treatment-d",
+          "slug": "treatment-d-informational",
           "ratio": 1,
           "groups": [
             "cfr"

--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -1146,5 +1146,488 @@
         }
       ]
     }
+  },
+  {
+    "id": "MESSAGE_ROUTER_PICTURE_IN_PICTURE_CFR",
+    "enabled": true,
+    "filter_expression": "env.channel == 'release' && env.version >= '78.' && env.version < '79.'",
+    "targeting": "locale == 'en-US' && userPrefs.cfrFeatures &&\n'media.videocontrols.picture-in-picture.enabled'|preferenceValue &&\n[userId, 'messaging-experiments-cfr']|bucketSample(5312, 650, 10000) &&\n((currentDate|date - profileAgeCreated) / 86400000) > 7\n",
+    "arguments": {
+      "slug": "bug-1656382-message-recommend-picture-in-picture-cfr-release-77-80",
+      "branches": [
+        {
+          "slug": "control",
+          "ratio": 1,
+          "value": {},
+          "groups": [
+            "cfr"
+          ]
+        },
+        {
+          "slug": "treatment-a",
+          "ratio": 1,
+          "groups": [
+            "cfr"
+          ],
+          "value": {
+            "id": "PIP_CFR_NEWS",
+            "groups": [
+              "cfr"
+            ],
+            "content": {
+              "bucket_id": "PIP_CFR_NEWS",
+              "buttons": {
+                "primary": {
+                  "action": {
+                    "data": {
+                      "args": "https://support.mozilla.org/en-US/kb/about-picture-picture-firefox",
+                      "where": "tabshifted"
+                    },
+                    "type": "OPEN_URL"
+                  },
+                  "label": {
+                    "value": "Learn More",
+                    "attributes": {
+                      "accesskey": "L"
+                    }
+                  }
+                },
+                "secondary": [
+                  {
+                    "action": {
+                      "type": "CANCEL"
+                    },
+                    "label": {
+                      "value": "Remind Me Later",
+                      "attributes": {
+                        "accesskey": "R"
+                      }
+                    }
+                  },
+                  {
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+                    }
+                  },
+                  {
+                    "action": {
+                      "data": {
+                        "category": "general-cfrfeatures"
+                      },
+                      "type": "OPEN_PREFERENCES_PAGE"
+                    },
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-manage-settings-button"
+                    }
+                  }
+                ]
+              },
+              "category": "cfrFeatures",
+              "heading_text": "Watch videos while you browse",
+              "icon": "chrome://global/skin/media/pictureinpicture.svg",
+              "info_icon": {
+                "label": {
+                  "string_id": "cfr-doorhanger-extension-sumo-link"
+                },
+                "sumo_path": "extensionrecommendations"
+              },
+              "layout": "icon_and_message",
+              "notification_text": {
+                "string_id": "cfr-doorhanger-extension-notification"
+              },
+              "text": "Keep yourself in the loop. With Picture-in-Picture you can watch the latest news while you visit other websites or apps - hover over a video and select the blue icon."
+            },
+            "frequency": {
+              "lifetime": 30,
+              "custom": [
+                {
+                  "period": 86400000,
+                  "cap": 1
+                }
+              ]
+            },
+            "targeting": "userPrefs.cfrFeatures",
+            "template": "cfr_doorhanger",
+            "trigger": {
+              "id": "openURL",
+              "params": [
+                "news.yahoo.com",
+                "news.google.com",
+                "huffingtonpost.com",
+                "cnn.com",
+                "nytimes.com",
+                "foxnews.com",
+                "nbcnews.com",
+                "dailymail.co.uk",
+                "washingtonpost.com",
+                "theguardian.com",
+                "wsj.com",
+                "abcnews.go.com",
+                "news.bbc.co.uk",
+                "latimes.com",
+                "cnbc.com",
+                "weather.com",
+                "bloomberg.com",
+                "reuters.com",
+                "usatoday.com",
+                "nypost.com",
+                "forbes.com",
+                "chicagotribune.com",
+                "msn.com",
+                "npr.org",
+                "tmz.com",
+                "today.com",
+                "buzzfeed.com"
+              ]
+            }
+          }
+        },
+        {
+          "slug": "treatment-b",
+          "ratio": 1,
+          "groups": [
+            "cfr"
+          ],
+          "value": {
+            "id": "PIP_CFR_SOCIAL_MEDIA",
+            "groups": [
+              "cfr"
+            ],
+            "content": {
+              "bucket_id": "PIP_CFR_SOCIAL_MEDIA",
+              "buttons": {
+                "primary": {
+                  "action": {
+                    "data": {
+                      "args": "https://support.mozilla.org/en-US/kb/about-picture-picture-firefox",
+                      "where": "tabshifted"
+                    },
+                    "type": "OPEN_URL"
+                  },
+                  "label": {
+                    "value": "Learn More",
+                    "attributes": {
+                      "accesskey": "L"
+                    }
+                  }
+                },
+                "secondary": [
+                  {
+                    "action": {
+                      "type": "CANCEL"
+                    },
+                    "label": {
+                      "value": "Remind Me Later",
+                      "attributes": {
+                        "accesskey": "R"
+                      }
+                    }
+                  },
+                  {
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+                    }
+                  },
+                  {
+                    "action": {
+                      "data": {
+                        "category": "general-cfrfeatures"
+                      },
+                      "type": "OPEN_PREFERENCES_PAGE"
+                    },
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-manage-settings-button"
+                    }
+                  }
+                ]
+              },
+              "category": "cfrFeatures",
+              "heading_text": "Watch videos while you browse",
+              "icon": "chrome://global/skin/media/pictureinpicture.svg",
+              "info_icon": {
+                "label": {
+                  "string_id": "cfr-doorhanger-extension-sumo-link"
+                },
+                "sumo_path": "extensionrecommendations"
+              },
+              "layout": "icon_and_message",
+              "notification_text": {
+                "string_id": "cfr-doorhanger-extension-notification"
+              },
+              "text": "Wish you could watch your favorite videos shared by your friends and family as you browse the web? You can with Picture-in-Picture - hover over a video and select the blue icon."
+            },
+            "frequency": {
+              "lifetime": 30,
+              "custom": [
+                {
+                  "period": 86400000,
+                  "cap": 1
+                }
+              ]
+            },
+            "targeting": "userPrefs.cfrFeatures",
+            "template": "cfr_doorhanger",
+            "trigger": {
+              "id": "openURL",
+              "params": [
+                "facebook.com",
+                "twitter.com",
+                "linkedin.com",
+                "instagram.com",
+                "tumblr.com",
+                "reddit.com",
+                "pinterest.com"
+              ]
+            }
+          }
+        },
+        {
+          "slug": "treatment-c",
+          "ratio": 1,
+          "groups": [
+            "cfr"
+          ],
+          "value": {
+            "id": "PIP_CFR_ENTERTAINMENT",
+            "groups": [
+              "cfr"
+            ],
+            "content": {
+              "bucket_id": "PIP_CFR_ENTERTAINMENT",
+              "buttons": {
+                "primary": {
+                  "action": {
+                    "data": {
+                      "args": "https://support.mozilla.org/en-US/kb/about-picture-picture-firefox",
+                      "where": "tabshifted"
+                    },
+                    "type": "OPEN_URL"
+                  },
+                  "label": {
+                    "value": "Learn More",
+                    "attributes": {
+                      "accesskey": "L"
+                    }
+                  }
+                },
+                "secondary": [
+                  {
+                    "action": {
+                      "type": "CANCEL"
+                    },
+                    "label": {
+                      "value": "Remind Me Later",
+                      "attributes": {
+                        "accesskey": "R"
+                      }
+                    }
+                  },
+                  {
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+                    }
+                  },
+                  {
+                    "action": {
+                      "data": {
+                        "category": "general-cfrfeatures"
+                      },
+                      "type": "OPEN_PREFERENCES_PAGE"
+                    },
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-manage-settings-button"
+                    }
+                  }
+                ]
+              },
+              "category": "cfrFeatures",
+              "heading_text": "Watch videos while you browse",
+              "icon": "chrome://global/skin/media/pictureinpicture.svg",
+              "info_icon": {
+                "label": {
+                  "string_id": "cfr-doorhanger-extension-sumo-link"
+                },
+                "sumo_path": "extensionrecommendations"
+              },
+              "layout": "icon_and_message",
+              "notification_text": {
+                "string_id": "cfr-doorhanger-extension-notification"
+              },
+              "text": "Catch up on your favorite shows! Guilt free binge watching with Picture-in-Picture - hover over a video and select the blue icon."
+            },
+            "frequency": {
+              "lifetime": 30,
+              "custom": [
+                {
+                  "period": 86400000,
+                  "cap": 1
+                }
+              ]
+            },
+            "targeting": "userPrefs.cfrFeatures",
+            "template": "cfr_doorhanger",
+            "trigger": {
+              "id": "openURL",
+              "params": [
+                "youtube.com",
+                "netflix.com",
+                "vimeo.com",
+                "twitch.com",
+                "dailymotion.com",
+                "hulu.com",
+                "ustream.com",
+                "metacafe.com",
+                "espn.com/watch",
+                "disneyplus.com",
+                "play.hbogo.com",
+                "primevideo.com"
+              ]
+            }
+          }
+        },
+        {
+          "slug": "treatment-d",
+          "ratio": 1,
+          "groups": [
+            "cfr"
+          ],
+          "value": {
+            "id": "PIP_CFR_INFORMATIONAL",
+            "groups": [
+              "cfr"
+            ],
+            "content": {
+              "bucket_id": "PIP_CFR_INFORMATIONAL",
+              "buttons": {
+                "primary": {
+                  "action": {
+                    "data": {
+                      "args": "https://support.mozilla.org/en-US/kb/about-picture-picture-firefox",
+                      "where": "tabshifted"
+                    },
+                    "type": "OPEN_URL"
+                  },
+                  "label": {
+                    "value": "Learn More",
+                    "attributes": {
+                      "accesskey": "L"
+                    }
+                  }
+                },
+                "secondary": [
+                  {
+                    "action": {
+                      "type": "CANCEL"
+                    },
+                    "label": {
+                      "value": "Remind Me Later",
+                      "attributes": {
+                        "accesskey": "R"
+                      }
+                    }
+                  },
+                  {
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+                    }
+                  },
+                  {
+                    "action": {
+                      "data": {
+                        "category": "general-cfrfeatures"
+                      },
+                      "type": "OPEN_PREFERENCES_PAGE"
+                    },
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-manage-settings-button"
+                    }
+                  }
+                ]
+              },
+              "category": "cfrFeatures",
+              "heading_text": "Watch videos while you browse",
+              "icon": "chrome://global/skin/media/pictureinpicture.svg",
+              "info_icon": {
+                "label": {
+                  "string_id": "cfr-doorhanger-extension-sumo-link"
+                },
+                "sumo_path": "extensionrecommendations"
+              },
+              "layout": "icon_and_message",
+              "notification_text": {
+                "string_id": "cfr-doorhanger-extension-notification"
+              },
+              "text": "Firefox's Picture-in-Picture lets you browse and watch videos at the same time - hover over a video and select the blue icon."
+            },
+            "frequency": {
+              "lifetime": 30,
+              "custom": [
+                {
+                  "period": 86400000,
+                  "cap": 1
+                }
+              ]
+            },
+            "targeting": "userPrefs.cfrFeatures",
+            "template": "cfr_doorhanger",
+            "trigger": {
+              "id": "openURL",
+              "params": [
+                "news.yahoo.com",
+                "news.google.com",
+                "huffingtonpost.com",
+                "cnn.com",
+                "nytimes.com",
+                "foxnews.com",
+                "nbcnews.com",
+                "dailymail.co.uk",
+                "washingtonpost.com",
+                "theguardian.com",
+                "wsj.com",
+                "abcnews.go.com",
+                "news.bbc.co.uk",
+                "latimes.com",
+                "cnbc.com",
+                "weather.com",
+                "bloomberg.com",
+                "reuters.com",
+                "usatoday.com",
+                "nypost.com",
+                "forbes.com",
+                "chicagotribune.com",
+                "msn.com",
+                "npr.org",
+                "tmz.com",
+                "today.com",
+                "buzzfeed.com",
+                "facebook.com",
+                "twitter.com",
+                "linkedin.com",
+                "instagram.com",
+                "tumblr.com",
+                "reddit.com",
+                "pinterest.com",
+                "youtube.com",
+                "netflix.com",
+                "vimeo.com",
+                "twitch.com",
+                "dailymotion.com",
+                "hulu.com",
+                "ustream.com",
+                "metacafe.com",
+                "espn.com/watch",
+                "disneyplus.com",
+                "play.hbogo.com",
+                "primevideo.com"
+              ]
+            }
+          }
+        }
+      ],
+      "userFacingName": "Recommend Picture-in-Picture CFR",
+      "isEnrollmentPaused": false,
+      "experimentDocumentUrl": "https://experimenter.services.mozilla.com/experiments/message-router-content-experiment-high-velocity-message-testing-cfr-to-pip/",
+      "userFacingDescription": "Message Router Content Experiment: High Velocity Message Testing: CFR to PiP"
+    }
   }
 ]

--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -1354,7 +1354,7 @@
               "notification_text": {
                 "string_id": "cfr-doorhanger-extension-notification"
               },
-              "text": "Wish you could watch your favorite videos shared by your friends and family as you browse the web? You can with Picture-in-Picture - hover over a video and select the blue icon."
+              "text": "Wish you could watch videos shared by your friends and family as you browse the web? You can with Picture-in-Picture - hover over a video and select the blue icon."
             },
             "frequency": {
               "lifetime": 30,
@@ -1453,7 +1453,7 @@
               "notification_text": {
                 "string_id": "cfr-doorhanger-extension-notification"
               },
-              "text": "Catch up on your favorite shows! Guilt free binge watching with Picture-in-Picture - hover over a video and select the blue icon."
+              "text": "Binge watch your favorite shows guilt-free with Picture-in-Picture - hover over a video and select the blue icon."
             },
             "frequency": {
               "lifetime": 30,
@@ -1557,7 +1557,7 @@
               "notification_text": {
                 "string_id": "cfr-doorhanger-extension-notification"
               },
-              "text": "Firefox's Picture-in-Picture lets you browse and watch videos at the same time - hover over a video and select the blue icon."
+              "text": "Picture-in-Picture lets you browse and watch videos at the same time - hover over a video and select the blue icon."
             },
             "frequency": {
               "lifetime": 30,

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -788,7 +788,8 @@
     locale == 'en-US' && userPrefs.cfrFeatures &&
     'media.videocontrols.picture-in-picture.enabled'|preferenceValue &&
     [userId, 'messaging-experiments-cfr']|bucketSample(5312, 650, 10000) &&
-    ((currentDate|date - profileAgeCreated) / 86400000) > 7
+    ((currentDate|date - profileAgeCreated) / 86400000) > 7 &&
+    'app.shield.optoutstudies.enabled'|preferenceValue
   arguments:
     slug: bug-1656382-message-recommend-picture-in-picture-cfr-release-77-80
     branches:
@@ -804,7 +805,7 @@
         value:
           id: PIP_CFR_NEWS
           groups:
-            - cfr
+            - cfr-experiments
           content:
             bucket_id: PIP_CFR_NEWS
             buttons:
@@ -846,7 +847,7 @@
             text: Keep yourself in the loop. With Picture-in-Picture you can watch the latest news while you visit other websites or apps - hover over a video and select the blue icon.
           frequency:
             # Per request, this experiment wants a larger lifetime frequency cap
-            lifetime: 30
+            lifetime: 3
             custom: [{period: 86400000, cap: 1}]
           targeting: "userPrefs.cfrFeatures"
           template: cfr_doorhanger
@@ -887,7 +888,7 @@
         value:
           id: PIP_CFR_SOCIAL_MEDIA
           groups:
-            - cfr
+            - cfr-experiments
           content:
             bucket_id: PIP_CFR_SOCIAL_MEDIA
             buttons:
@@ -928,7 +929,7 @@
               string_id: cfr-doorhanger-extension-notification
             text: Wish you could watch videos shared by your friends and family as you browse the web? You can with Picture-in-Picture - hover over a video and select the blue icon.
           frequency:
-            lifetime: 30
+            lifetime: 3
             custom: [{period: 86400000, cap: 1}]
           targeting: "userPrefs.cfrFeatures"
           template: cfr_doorhanger
@@ -949,7 +950,7 @@
         value:
           id: PIP_CFR_ENTERTAINMENT
           groups:
-            - cfr
+            - cfr-experiments
           content:
             bucket_id: PIP_CFR_ENTERTAINMENT
             buttons:
@@ -990,7 +991,7 @@
               string_id: cfr-doorhanger-extension-notification
             text: Binge watch your favorite shows guilt-free with Picture-in-Picture - hover over a video and select the blue icon.
           frequency:
-            lifetime: 30
+            lifetime: 3
             custom: [{period: 86400000, cap: 1}]
           targeting: "userPrefs.cfrFeatures"
           template: cfr_doorhanger
@@ -1016,7 +1017,7 @@
         value:
           id: PIP_CFR_INFORMATIONAL
           groups:
-            - cfr
+            - cfr-experiments
           content:
             bucket_id: PIP_CFR_INFORMATIONAL
             buttons:
@@ -1057,7 +1058,7 @@
               string_id: cfr-doorhanger-extension-notification
             text: Picture-in-Picture lets you browse and watch videos at the same time - hover over a video and select the blue icon.
           frequency:
-            lifetime: 30
+            lifetime: 3
             custom: [{period: 86400000, cap: 1}]
           targeting: "userPrefs.cfrFeatures"
           template: cfr_doorhanger

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -782,23 +782,24 @@
               - https://*/*
 - id: MESSAGE_ROUTER_PICTURE_IN_PICTURE_CFR
   enabled: true
-  filter_expression: env.channel == 'release' && env.version >= '78.' && env.version < '79.'
-  # 6.5% of release
+  filter_expression: env.channel == 'release' && env.version >= '78.' && env.version < '80.'
+  # 5% of release
   targeting: |
     locale == 'en-US' && userPrefs.cfrFeatures &&
+    platformName in ["win", "macosx"] &&
     'media.videocontrols.picture-in-picture.enabled'|preferenceValue &&
-    [userId, 'messaging-experiments-cfr']|bucketSample(5312, 650, 10000) &&
+    [userId, 'messaging-experiments-cfr']|bucketSample(5312, 500, 10000) &&
     ((currentDate|date - profileAgeCreated) / 86400000) > 7 &&
     'app.shield.optoutstudies.enabled'|preferenceValue
   arguments:
-    slug: bug-1656382-message-recommend-picture-in-picture-cfr-release-77-80
+    slug: bug-1658301-message-message-router-content-experiment-high-veloci-release-78-80
     branches:
       - slug: control
         ratio: 1
         value: {}
         groups:
           - cfr
-      - slug: treatment-a
+      - slug: treatment-a-news
         ratio: 1
         groups:
           - cfr
@@ -881,7 +882,7 @@
               - tmz.com
               - today.com
               - buzzfeed.com
-      - slug: treatment-b
+      - slug: treatment-b-social-media
         ratio: 1
         groups:
           - cfr
@@ -943,7 +944,7 @@
               - tumblr.com
               - reddit.com
               - pinterest.com
-      - slug: treatment-c
+      - slug: treatment-c-entertainment
         ratio: 1
         groups:
           - cfr
@@ -1010,7 +1011,7 @@
               - disneyplus.com
               - play.hbogo.com
               - primevideo.com
-      - slug: treatment-d
+      - slug: treatment-d-informational
         ratio: 1
         groups:
           - cfr

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -926,7 +926,7 @@
             layout: icon_and_message
             notification_text:
               string_id: cfr-doorhanger-extension-notification
-            text: Wish you could watch your favorite videos shared by your friends and family as you browse the web? You can with Picture-in-Picture - hover over a video and select the blue icon.
+            text: Wish you could watch videos shared by your friends and family as you browse the web? You can with Picture-in-Picture - hover over a video and select the blue icon.
           frequency:
             lifetime: 30
             custom: [{period: 86400000, cap: 1}]
@@ -988,7 +988,7 @@
             layout: icon_and_message
             notification_text:
               string_id: cfr-doorhanger-extension-notification
-            text: Catch up on your favorite shows! Guilt free binge watching with Picture-in-Picture - hover over a video and select the blue icon.
+            text: Binge watch your favorite shows guilt-free with Picture-in-Picture - hover over a video and select the blue icon.
           frequency:
             lifetime: 30
             custom: [{period: 86400000, cap: 1}]
@@ -1055,7 +1055,7 @@
             layout: icon_and_message
             notification_text:
               string_id: cfr-doorhanger-extension-notification
-            text: Firefox's Picture-in-Picture lets you browse and watch videos at the same time - hover over a video and select the blue icon.
+            text: Picture-in-Picture lets you browse and watch videos at the same time - hover over a video and select the blue icon.
           frequency:
             lifetime: 30
             custom: [{period: 86400000, cap: 1}]

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -780,3 +780,337 @@
             patterns:
               - http://*/*
               - https://*/*
+- id: MESSAGE_ROUTER_PICTURE_IN_PICTURE_CFR
+  enabled: true
+  filter_expression: env.channel == 'release' && env.version >= '78.' && env.version < '79.'
+  # 6.5% of release
+  targeting: |
+    locale == 'en-US' && userPrefs.cfrFeatures &&
+    'media.videocontrols.picture-in-picture.enabled'|preferenceValue &&
+    [userId, 'messaging-experiments-cfr']|bucketSample(5312, 650, 10000) &&
+    ((currentDate|date - profileAgeCreated) / 86400000) > 7
+  arguments:
+    slug: bug-1656382-message-recommend-picture-in-picture-cfr-release-77-80
+    branches:
+      - slug: control
+        ratio: 1
+        value: {}
+        groups:
+          - cfr
+      - slug: treatment-a
+        ratio: 1
+        groups:
+          - cfr
+        value:
+          id: PIP_CFR_NEWS
+          groups:
+            - cfr
+          content:
+            bucket_id: PIP_CFR_NEWS
+            buttons:
+              primary:
+                action:
+                  data:
+                    args: https://support.mozilla.org/en-US/kb/about-picture-picture-firefox
+                    where: tabshifted
+                  type: OPEN_URL
+                label:
+                  value: Learn More
+                  attributes:
+                    accesskey: L
+              secondary:
+                - action:
+                    type: CANCEL
+                  label:
+                    value: Remind Me Later
+                    attributes:
+                      accesskey: R
+                - label:
+                    string_id: cfr-doorhanger-extension-never-show-recommendation
+                - action:
+                    data:
+                      category: general-cfrfeatures
+                    type: OPEN_PREFERENCES_PAGE
+                  label:
+                    string_id: cfr-doorhanger-extension-manage-settings-button
+            category: cfrFeatures
+            heading_text: Watch videos while you browse
+            icon: chrome://global/skin/media/pictureinpicture.svg
+            info_icon:
+              label:
+                string_id: cfr-doorhanger-extension-sumo-link
+              sumo_path: extensionrecommendations
+            layout: icon_and_message
+            notification_text:
+              string_id: cfr-doorhanger-extension-notification
+            text: Keep yourself in the loop. With Picture-in-Picture you can watch the latest news while you visit other websites or apps - hover over a video and select the blue icon.
+          frequency:
+            # Per request, this experiment wants a larger lifetime frequency cap
+            lifetime: 30
+            custom: [{period: 86400000, cap: 1}]
+          targeting: "userPrefs.cfrFeatures"
+          template: cfr_doorhanger
+          trigger:
+            id: openURL
+            params:
+              - news.yahoo.com
+              - news.google.com
+              - huffingtonpost.com
+              - cnn.com
+              - nytimes.com
+              - foxnews.com
+              - nbcnews.com
+              - dailymail.co.uk
+              - washingtonpost.com
+              - theguardian.com
+              - wsj.com
+              - abcnews.go.com
+              - news.bbc.co.uk
+              - latimes.com
+              - cnbc.com
+              - weather.com
+              - bloomberg.com
+              - reuters.com
+              - usatoday.com
+              - nypost.com
+              - forbes.com
+              - chicagotribune.com
+              - msn.com
+              - npr.org
+              - tmz.com
+              - today.com
+              - buzzfeed.com
+      - slug: treatment-b
+        ratio: 1
+        groups:
+          - cfr
+        value:
+          id: PIP_CFR_SOCIAL_MEDIA
+          groups:
+            - cfr
+          content:
+            bucket_id: PIP_CFR_SOCIAL_MEDIA
+            buttons:
+              primary:
+                action:
+                  data:
+                    args: https://support.mozilla.org/en-US/kb/about-picture-picture-firefox
+                    where: tabshifted
+                  type: OPEN_URL
+                label:
+                  value: Learn More
+                  attributes:
+                    accesskey: L
+              secondary:
+                - action:
+                    type: CANCEL
+                  label:
+                    value: Remind Me Later
+                    attributes:
+                      accesskey: R
+                - label:
+                    string_id: cfr-doorhanger-extension-never-show-recommendation
+                - action:
+                    data:
+                      category: general-cfrfeatures
+                    type: OPEN_PREFERENCES_PAGE
+                  label:
+                    string_id: cfr-doorhanger-extension-manage-settings-button
+            category: cfrFeatures
+            heading_text: Watch videos while you browse
+            icon: chrome://global/skin/media/pictureinpicture.svg
+            info_icon:
+              label:
+                string_id: cfr-doorhanger-extension-sumo-link
+              sumo_path: extensionrecommendations
+            layout: icon_and_message
+            notification_text:
+              string_id: cfr-doorhanger-extension-notification
+            text: Wish you could watch your favorite videos shared by your friends and family as you browse the web? You can with Picture-in-Picture - hover over a video and select the blue icon.
+          frequency:
+            lifetime: 30
+            custom: [{period: 86400000, cap: 1}]
+          targeting: "userPrefs.cfrFeatures"
+          template: cfr_doorhanger
+          trigger:
+            id: openURL
+            params:
+              - facebook.com
+              - twitter.com
+              - linkedin.com
+              - instagram.com
+              - tumblr.com
+              - reddit.com
+              - pinterest.com
+      - slug: treatment-c
+        ratio: 1
+        groups:
+          - cfr
+        value:
+          id: PIP_CFR_ENTERTAINMENT
+          groups:
+            - cfr
+          content:
+            bucket_id: PIP_CFR_ENTERTAINMENT
+            buttons:
+              primary:
+                action:
+                  data:
+                    args: https://support.mozilla.org/en-US/kb/about-picture-picture-firefox
+                    where: tabshifted
+                  type: OPEN_URL
+                label:
+                  value: Learn More
+                  attributes:
+                    accesskey: L
+              secondary:
+                - action:
+                    type: CANCEL
+                  label:
+                    value: Remind Me Later
+                    attributes:
+                      accesskey: R
+                - label:
+                    string_id: cfr-doorhanger-extension-never-show-recommendation
+                - action:
+                    data:
+                      category: general-cfrfeatures
+                    type: OPEN_PREFERENCES_PAGE
+                  label:
+                    string_id: cfr-doorhanger-extension-manage-settings-button
+            category: cfrFeatures
+            heading_text: Watch videos while you browse
+            icon: chrome://global/skin/media/pictureinpicture.svg
+            info_icon:
+              label:
+                string_id: cfr-doorhanger-extension-sumo-link
+              sumo_path: extensionrecommendations
+            layout: icon_and_message
+            notification_text:
+              string_id: cfr-doorhanger-extension-notification
+            text: Catch up on your favorite shows! Guilt free binge watching with Picture-in-Picture - hover over a video and select the blue icon.
+          frequency:
+            lifetime: 30
+            custom: [{period: 86400000, cap: 1}]
+          targeting: "userPrefs.cfrFeatures"
+          template: cfr_doorhanger
+          trigger:
+            id: openURL
+            params:
+              - youtube.com
+              - netflix.com
+              - vimeo.com
+              - twitch.com
+              - dailymotion.com
+              - hulu.com
+              - ustream.com
+              - metacafe.com
+              - espn.com/watch
+              - disneyplus.com
+              - play.hbogo.com
+              - primevideo.com
+      - slug: treatment-d
+        ratio: 1
+        groups:
+          - cfr
+        value:
+          id: PIP_CFR_INFORMATIONAL
+          groups:
+            - cfr
+          content:
+            bucket_id: PIP_CFR_INFORMATIONAL
+            buttons:
+              primary:
+                action:
+                  data:
+                    args: https://support.mozilla.org/en-US/kb/about-picture-picture-firefox
+                    where: tabshifted
+                  type: OPEN_URL
+                label:
+                  value: Learn More
+                  attributes:
+                    accesskey: L
+              secondary:
+                - action:
+                    type: CANCEL
+                  label:
+                    value: Remind Me Later
+                    attributes:
+                      accesskey: R
+                - label:
+                    string_id: cfr-doorhanger-extension-never-show-recommendation
+                - action:
+                    data:
+                      category: general-cfrfeatures
+                    type: OPEN_PREFERENCES_PAGE
+                  label:
+                    string_id: cfr-doorhanger-extension-manage-settings-button
+            category: cfrFeatures
+            heading_text: Watch videos while you browse
+            icon: chrome://global/skin/media/pictureinpicture.svg
+            info_icon:
+              label:
+                string_id: cfr-doorhanger-extension-sumo-link
+              sumo_path: extensionrecommendations
+            layout: icon_and_message
+            notification_text:
+              string_id: cfr-doorhanger-extension-notification
+            text: Firefox's Picture-in-Picture lets you browse and watch videos at the same time - hover over a video and select the blue icon.
+          frequency:
+            lifetime: 30
+            custom: [{period: 86400000, cap: 1}]
+          targeting: "userPrefs.cfrFeatures"
+          template: cfr_doorhanger
+          trigger:
+            id: openURL
+            params:
+              - news.yahoo.com
+              - news.google.com
+              - huffingtonpost.com
+              - cnn.com
+              - nytimes.com
+              - foxnews.com
+              - nbcnews.com
+              - dailymail.co.uk
+              - washingtonpost.com
+              - theguardian.com
+              - wsj.com
+              - abcnews.go.com
+              - news.bbc.co.uk
+              - latimes.com
+              - cnbc.com
+              - weather.com
+              - bloomberg.com
+              - reuters.com
+              - usatoday.com
+              - nypost.com
+              - forbes.com
+              - chicagotribune.com
+              - msn.com
+              - npr.org
+              - tmz.com
+              - today.com
+              - buzzfeed.com
+              - facebook.com
+              - twitter.com
+              - linkedin.com
+              - instagram.com
+              - tumblr.com
+              - reddit.com
+              - pinterest.com
+              - youtube.com
+              - netflix.com
+              - vimeo.com
+              - twitch.com
+              - dailymotion.com
+              - hulu.com
+              - ustream.com
+              - metacafe.com
+              - espn.com/watch
+              - disneyplus.com
+              - play.hbogo.com
+              - primevideo.com
+    userFacingName: Recommend Picture-in-Picture CFR
+    isEnrollmentPaused: false
+    experimentDocumentUrl: https://experimenter.services.mozilla.com/experiments/message-router-content-experiment-high-velocity-message-testing-cfr-to-pip/
+    userFacingDescription: "Message Router Content Experiment: High Velocity Message Testing: CFR to PiP"


### PR DESCRIPTION
Yes, this experiment is targeting Firefox *78*.

Experimenter ticket: https://experimenter.services.mozilla.com/experiments/message-router-content-experiment-high-velocity-message-testing-cfr-to-pip/