### PR TITLE
Change floats to string in CFR addon recommendation messages

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -7,7 +7,7 @@
         "author": "Maxime RF",
         "icon": "resource://activity-stream/data/content/assets/cfr_enhancer_youtube.png",
         "id": "700308",
-        "rating": 4.7,
+        "rating": "4.7",
         "title": "Enhancer for YouTube\u2122",
         "users": 807032
       },
@@ -89,7 +89,7 @@
         "author": "Juan Escobar",
         "icon": "resource://activity-stream/data/content/assets/cfr_google_translate.png",
         "id": "445852",
-        "rating": 4.2,
+        "rating": "4.2",
         "title": "To Google Translate",
         "users": 623523
       },
@@ -169,7 +169,7 @@
         "author": "Mozilla",
         "icon": "resource://activity-stream/data/content/assets/cfr_fb_container.png",
         "id": "954390",
-        "rating": 4.5,
+        "rating": "4.5",
         "title": "Facebook Container",
         "users": 1455872
       },

--- a/cfr.json
+++ b/cfr.json
@@ -89,7 +89,7 @@
         "author": "Juan Escobar",
         "icon": "resource://activity-stream/data/content/assets/cfr_google_translate.png",
         "id": "445852",
-        "rating": "4.2",
+        "rating": "4.1",
         "title": "To Google Translate",
         "users": 623523
       },
@@ -169,7 +169,7 @@
         "author": "Mozilla",
         "icon": "resource://activity-stream/data/content/assets/cfr_fb_container.png",
         "id": "954390",
-        "rating": "4.5",
+        "rating": "4.4",
         "title": "Facebook Container",
         "users": 1455872
       },

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -65,7 +65,7 @@
       author: Juan Escobar
       icon: resource://activity-stream/data/content/assets/cfr_google_translate.png
       id: '445852'
-      rating: "4.2"
+      rating: "4.1"
       title: To Google Translate
       users: 623523
     bucket_id: CFR_M1
@@ -129,7 +129,7 @@
       author: Mozilla
       icon: resource://activity-stream/data/content/assets/cfr_fb_container.png
       id: '954390'
-      rating: "4.5"
+      rating: "4.4"
       title: Facebook Container
       users: 1455872
     bucket_id: CFR_M1

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -5,7 +5,7 @@
       author: Maxime RF
       icon: resource://activity-stream/data/content/assets/cfr_enhancer_youtube.png
       id: '700308'
-      rating: 4.7
+      rating: "4.7"
       title: "Enhancer for YouTube\u2122"
       users: 807032
     bucket_id: CFR_M1
@@ -65,7 +65,7 @@
       author: Juan Escobar
       icon: resource://activity-stream/data/content/assets/cfr_google_translate.png
       id: '445852'
-      rating: 4.2
+      rating: "4.2"
       title: To Google Translate
       users: 623523
     bucket_id: CFR_M1
@@ -129,7 +129,7 @@
       author: Mozilla
       icon: resource://activity-stream/data/content/assets/cfr_fb_container.png
       id: '954390'
-      rating: 4.5
+      rating: "4.5"
       title: Facebook Container
       users: 1455872
     bucket_id: CFR_M1

--- a/schema/cfr.schema.json
+++ b/schema/cfr.schema.json
@@ -184,9 +184,7 @@
               ]
             },
             "rating": {
-              "type": "number",
-              "minimum": 0,
-              "maximum": 5,
+              "type": "string",
               "description": "Star rating"
             },
             "users": {


### PR DESCRIPTION
Changing float to strings to match with Remote Settings changes.
This happens to work because [the way the value is used](https://searchfox.org/mozilla-central/rev/8a0745cd346f0cfb89ae71690babbf7bff706113/browser/components/newtab/lib/CFRPageActions.jsm#394): when dividing a string by an integer the string is casted to a float*.
We considered updating the code to properly call `parseFloat` but we would need to wait for the changes to ride the trains (and then there's ESR).

*it's not a bug it's a feature