### PR TITLE
Bug 1667607 - CFR icons are loaded using the chrome: protocol startining Fx82

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -1,11 +1,11 @@
 [
   {
-    "id": "YOUTUBE_ENHANCE_3_72",
+    "id": "YOUTUBE_ENHANCE_3_82",
     "content": {
       "addon": {
         "amo_url": "https://addons.mozilla.org/firefox/addon/enhancer-for-youtube/",
         "author": "Maxime RF",
-        "icon": "resource://activity-stream/data/content/assets/cfr_enhancer_youtube.png",
+        "icon": "chrome://activity-stream/content/data/content/assets/cfr_enhancer_youtube.png",
         "id": "700308",
         "rating": "4.7",
         "title": "Enhancer for YouTube\u2122",
@@ -71,7 +71,7 @@
     "frequency": {
       "lifetime": 3
     },
-    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"enhancerforyoutube@maximerf.addons.mozilla.org\",\"{dc8f61ab-5e98-4027-98ef-bb2ff6060d71}\",\"{7b1bf0b6-a1b9-42b0-b75d-252036438bdc}\",\"jid0-UVAeBCfd34Kk5usS8A1CBiobvM8@jetpack\",\"iridium@particlecore.github.io\",\"jid1-ss6kLNCbNz6u0g@jetpack\",\"{1cf918d2-f4ea-4b4f-b34e-455283fef19f}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.youtube.com\",\"youtube.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons",
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"enhancerforyoutube@maximerf.addons.mozilla.org\",\"{dc8f61ab-5e98-4027-98ef-bb2ff6060d71}\",\"{7b1bf0b6-a1b9-42b0-b75d-252036438bdc}\",\"jid0-UVAeBCfd34Kk5usS8A1CBiobvM8@jetpack\",\"iridium@particlecore.github.io\",\"jid1-ss6kLNCbNz6u0g@jetpack\",\"{1cf918d2-f4ea-4b4f-b34e-455283fef19f}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.youtube.com\",\"youtube.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 82 && userPrefs.cfrAddons",
     "template": "cfr_doorhanger",
     "trigger": {
       "id": "openURL",
@@ -82,12 +82,12 @@
     }
   },
   {
-    "id": "GOOGLE_TRANSLATE_3_72",
+    "id": "GOOGLE_TRANSLATE_3_82",
     "content": {
       "addon": {
         "amo_url": "https://addons.mozilla.org/firefox/addon/to-google-translate/",
         "author": "Juan Escobar",
-        "icon": "resource://activity-stream/data/content/assets/cfr_google_translate.png",
+        "icon": "chrome://activity-stream/content/data/content/assets/cfr_google_translate.png",
         "id": "445852",
         "rating": "4.1",
         "title": "To Google Translate",
@@ -152,7 +152,7 @@
     "frequency": {
       "lifetime": 3
     },
-    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"jid1-93WyvpgvxzGATw@jetpack\",\"{087ef4e1-4286-4be6-9aa3-8d6c420ee1db}\",\"{4170faaa-ee87-4a0e-b57a-1aec49282887}\",\"jid1-TMndP6cdKgxLcQ@jetpack\",\"s3google@translator\",\"{9c63d15c-b4d9-43bd-b223-37f0a1f22e2a}\",\"translator@zoli.bod\",\"{8cda9ce6-7893-4f47-ac70-a65215cec288}\",\"simple-translate@sienori\",\"@translatenow\",\"{a79fafce-8da6-4685-923f-7ba1015b8748})\",\"{8a802b5a-eeab-11e2-a41d-b0096288709b}\",\"jid0-fbHwsGfb6kJyq2hj65KnbGte3yT@jetpack\",\"storetranslate.plugin@gmail.com\",\"jid1-r2tWDbSkq8AZK1@jetpack\",\"{b384b75c-c978-4c4d-b3cf-62a82d8f8f12}\",\"jid1-f7dnBeTj8ElpWQ@jetpack\",\"{dac8a935-4775-4918-9205-5c0600087dc4}\",\"gtranslation2@slam.com\",\"{e20e0de5-1667-4df4-bd69-705720e37391}\",\"{09e26ae9-e9c1-477c-80a6-99934212f2fe}\",\"mgxtranslator@magemagix.com\",\"gtranslatewins@mozilla.org\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"translate.google.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons",
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"jid1-93WyvpgvxzGATw@jetpack\",\"{087ef4e1-4286-4be6-9aa3-8d6c420ee1db}\",\"{4170faaa-ee87-4a0e-b57a-1aec49282887}\",\"jid1-TMndP6cdKgxLcQ@jetpack\",\"s3google@translator\",\"{9c63d15c-b4d9-43bd-b223-37f0a1f22e2a}\",\"translator@zoli.bod\",\"{8cda9ce6-7893-4f47-ac70-a65215cec288}\",\"simple-translate@sienori\",\"@translatenow\",\"{a79fafce-8da6-4685-923f-7ba1015b8748})\",\"{8a802b5a-eeab-11e2-a41d-b0096288709b}\",\"jid0-fbHwsGfb6kJyq2hj65KnbGte3yT@jetpack\",\"storetranslate.plugin@gmail.com\",\"jid1-r2tWDbSkq8AZK1@jetpack\",\"{b384b75c-c978-4c4d-b3cf-62a82d8f8f12}\",\"jid1-f7dnBeTj8ElpWQ@jetpack\",\"{dac8a935-4775-4918-9205-5c0600087dc4}\",\"gtranslation2@slam.com\",\"{e20e0de5-1667-4df4-bd69-705720e37391}\",\"{09e26ae9-e9c1-477c-80a6-99934212f2fe}\",\"mgxtranslator@magemagix.com\",\"gtranslatewins@mozilla.org\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"translate.google.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 82 && userPrefs.cfrAddons",
     "template": "cfr_doorhanger",
     "trigger": {
       "id": "openURL",
@@ -162,12 +162,12 @@
     }
   },
   {
-    "id": "FACEBOOK_CONTAINER_3_72",
+    "id": "FACEBOOK_CONTAINER_3_82",
     "content": {
       "addon": {
         "amo_url": "https://addons.mozilla.org/firefox/addon/facebook-container/",
         "author": "Mozilla",
-        "icon": "resource://activity-stream/data/content/assets/cfr_fb_container.png",
+        "icon": "chrome://activity-stream/content/data/content/assets/cfr_fb_container.png",
         "id": "954390",
         "rating": "4.4",
         "title": "Facebook Container",
@@ -232,7 +232,7 @@
     "frequency": {
       "lifetime": 3
     },
-    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"@contain-facebook\",\"{bb1b80be-e6b3-40a1-9b6e-9d4073343f0b}\",\"{a50d61ca-d27b-437a-8b52-5fd801a0a88b}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.facebook.com\",\"facebook.com\",\"messenger.com\",\"www.messenger.com\",\"instagram.com\",\"www.instagram.com\",\"whatsapp.com\",\"www.whatsapp.com\",\"web.whatsapp.com\"]intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && userPrefs.cfrAddons",
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"@contain-facebook\",\"{bb1b80be-e6b3-40a1-9b6e-9d4073343f0b}\",\"{a50d61ca-d27b-437a-8b52-5fd801a0a88b}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.facebook.com\",\"facebook.com\",\"messenger.com\",\"www.messenger.com\",\"instagram.com\",\"www.instagram.com\",\"whatsapp.com\",\"www.whatsapp.com\",\"web.whatsapp.com\"]intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && userPrefs.cfrAddons && firefoxVersion >= 82",
     "template": "cfr_doorhanger",
     "trigger": {
       "id": "openURL",
@@ -1367,6 +1367,256 @@
       "id": "openURL",
       "patterns": [
         "*://*/*"
+      ]
+    }
+  },
+  {
+    "id": "YOUTUBE_ENHANCE_3_72",
+    "content": {
+      "addon": {
+        "amo_url": "https://addons.mozilla.org/firefox/addon/enhancer-for-youtube/",
+        "author": "Maxime RF",
+        "icon": "resource://activity-stream/data/content/assets/cfr_enhancer_youtube.png",
+        "id": "700308",
+        "rating": "4.7",
+        "title": "Enhancer for YouTube\u2122",
+        "users": 807032
+      },
+      "bucket_id": "CFR_M1",
+      "buttons": {
+        "primary": {
+          "action": {
+            "data": {
+              "url": null
+            },
+            "type": "INSTALL_ADDON_FROM_URL"
+          },
+          "label": {
+            "string_id": "cfr-doorhanger-extension-ok-button"
+          }
+        },
+        "secondary": [
+          {
+            "action": {
+              "type": "CANCEL"
+            },
+            "label": {
+              "string_id": "cfr-doorhanger-extension-cancel-button"
+            }
+          },
+          {
+            "label": {
+              "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+            }
+          },
+          {
+            "action": {
+              "data": {
+                "category": "general-cfraddons",
+                "origin": "CFR"
+              },
+              "type": "OPEN_PREFERENCES_PAGE"
+            },
+            "label": {
+              "string_id": "cfr-doorhanger-extension-manage-settings-button"
+            }
+          }
+        ]
+      },
+      "category": "cfrAddons",
+      "heading_text": {
+        "string_id": "cfr-doorhanger-extension-heading"
+      },
+      "info_icon": {
+        "label": {
+          "string_id": "cfr-doorhanger-extension-sumo-link"
+        },
+        "sumo_path": "extensionrecommendations"
+      },
+      "layout": "addon_recommendation",
+      "notification_text": {
+        "string_id": "cfr-doorhanger-extension-notification2"
+      },
+      "text": "Take control of your YouTube experience. Automatically block annoying ads, set playback speed and volume, remove annotations, and more."
+    },
+    "frequency": {
+      "lifetime": 3
+    },
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"enhancerforyoutube@maximerf.addons.mozilla.org\",\"{dc8f61ab-5e98-4027-98ef-bb2ff6060d71}\",\"{7b1bf0b6-a1b9-42b0-b75d-252036438bdc}\",\"jid0-UVAeBCfd34Kk5usS8A1CBiobvM8@jetpack\",\"iridium@particlecore.github.io\",\"jid1-ss6kLNCbNz6u0g@jetpack\",\"{1cf918d2-f4ea-4b4f-b34e-455283fef19f}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.youtube.com\",\"youtube.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons",
+    "template": "cfr_doorhanger",
+    "trigger": {
+      "id": "openURL",
+      "params": [
+        "www.youtube.com",
+        "youtube.com"
+      ]
+    }
+  },
+  {
+    "id": "GOOGLE_TRANSLATE_3_72",
+    "content": {
+      "addon": {
+        "amo_url": "https://addons.mozilla.org/firefox/addon/to-google-translate/",
+        "author": "Juan Escobar",
+        "icon": "resource://activity-stream/data/content/assets/cfr_google_translate.png",
+        "id": "445852",
+        "rating": "4.1",
+        "title": "To Google Translate",
+        "users": 623523
+      },
+      "bucket_id": "CFR_M1",
+      "buttons": {
+        "primary": {
+          "action": {
+            "data": {
+              "url": null
+            },
+            "type": "INSTALL_ADDON_FROM_URL"
+          },
+          "label": {
+            "string_id": "cfr-doorhanger-extension-ok-button"
+          }
+        },
+        "secondary": [
+          {
+            "action": {
+              "type": "CANCEL"
+            },
+            "label": {
+              "string_id": "cfr-doorhanger-extension-cancel-button"
+            }
+          },
+          {
+            "label": {
+              "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+            }
+          },
+          {
+            "action": {
+              "data": {
+                "category": "general-cfraddons",
+                "origin": "CFR"
+              },
+              "type": "OPEN_PREFERENCES_PAGE"
+            },
+            "label": {
+              "string_id": "cfr-doorhanger-extension-manage-settings-button"
+            }
+          }
+        ]
+      },
+      "category": "cfrAddons",
+      "heading_text": {
+        "string_id": "cfr-doorhanger-extension-heading"
+      },
+      "info_icon": {
+        "label": {
+          "string_id": "cfr-doorhanger-extension-sumo-link"
+        },
+        "sumo_path": "extensionrecommendations"
+      },
+      "notification_text": {
+        "string_id": "cfr-doorhanger-extension-notification2"
+      },
+      "text": "Instantly translate any webpage text. Simply highlight the text, right-click to open the context menu, and choose a text or aural translation."
+    },
+    "frequency": {
+      "lifetime": 3
+    },
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"jid1-93WyvpgvxzGATw@jetpack\",\"{087ef4e1-4286-4be6-9aa3-8d6c420ee1db}\",\"{4170faaa-ee87-4a0e-b57a-1aec49282887}\",\"jid1-TMndP6cdKgxLcQ@jetpack\",\"s3google@translator\",\"{9c63d15c-b4d9-43bd-b223-37f0a1f22e2a}\",\"translator@zoli.bod\",\"{8cda9ce6-7893-4f47-ac70-a65215cec288}\",\"simple-translate@sienori\",\"@translatenow\",\"{a79fafce-8da6-4685-923f-7ba1015b8748})\",\"{8a802b5a-eeab-11e2-a41d-b0096288709b}\",\"jid0-fbHwsGfb6kJyq2hj65KnbGte3yT@jetpack\",\"storetranslate.plugin@gmail.com\",\"jid1-r2tWDbSkq8AZK1@jetpack\",\"{b384b75c-c978-4c4d-b3cf-62a82d8f8f12}\",\"jid1-f7dnBeTj8ElpWQ@jetpack\",\"{dac8a935-4775-4918-9205-5c0600087dc4}\",\"gtranslation2@slam.com\",\"{e20e0de5-1667-4df4-bd69-705720e37391}\",\"{09e26ae9-e9c1-477c-80a6-99934212f2fe}\",\"mgxtranslator@magemagix.com\",\"gtranslatewins@mozilla.org\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"translate.google.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons",
+    "template": "cfr_doorhanger",
+    "trigger": {
+      "id": "openURL",
+      "params": [
+        "translate.google.com"
+      ]
+    }
+  },
+  {
+    "id": "FACEBOOK_CONTAINER_3_72",
+    "content": {
+      "addon": {
+        "amo_url": "https://addons.mozilla.org/firefox/addon/facebook-container/",
+        "author": "Mozilla",
+        "icon": "resource://activity-stream/data/content/assets/cfr_fb_container.png",
+        "id": "954390",
+        "rating": "4.4",
+        "title": "Facebook Container",
+        "users": 1455872
+      },
+      "bucket_id": "CFR_M1",
+      "buttons": {
+        "primary": {
+          "action": {
+            "data": {
+              "url": null
+            },
+            "type": "INSTALL_ADDON_FROM_URL"
+          },
+          "label": {
+            "string_id": "cfr-doorhanger-extension-ok-button"
+          }
+        },
+        "secondary": [
+          {
+            "action": {
+              "type": "CANCEL"
+            },
+            "label": {
+              "string_id": "cfr-doorhanger-extension-cancel-button"
+            }
+          },
+          {
+            "label": {
+              "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+            }
+          },
+          {
+            "action": {
+              "data": {
+                "category": "general-cfraddons",
+                "origin": "CFR"
+              },
+              "type": "OPEN_PREFERENCES_PAGE"
+            },
+            "label": {
+              "string_id": "cfr-doorhanger-extension-manage-settings-button"
+            }
+          }
+        ]
+      },
+      "category": "cfrAddons",
+      "heading_text": {
+        "string_id": "cfr-doorhanger-extension-heading"
+      },
+      "info_icon": {
+        "label": {
+          "string_id": "cfr-doorhanger-extension-sumo-link"
+        },
+        "sumo_path": "extensionrecommendations"
+      },
+      "notification_text": {
+        "string_id": "cfr-doorhanger-extension-notification2"
+      },
+      "text": "Stop Facebook from tracking your activity across the web. Use Facebook the way you normally do without annoying ads following you around."
+    },
+    "frequency": {
+      "lifetime": 3
+    },
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"@contain-facebook\",\"{bb1b80be-e6b3-40a1-9b6e-9d4073343f0b}\",\"{a50d61ca-d27b-437a-8b52-5fd801a0a88b}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.facebook.com\",\"facebook.com\",\"messenger.com\",\"www.messenger.com\",\"instagram.com\",\"www.instagram.com\",\"whatsapp.com\",\"www.whatsapp.com\",\"web.whatsapp.com\"]intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons",
+    "template": "cfr_doorhanger",
+    "trigger": {
+      "id": "openURL",
+      "params": [
+        "www.facebook.com",
+        "facebook.com",
+        "www.instagram.com",
+        "instagram.com",
+        "www.whatsapp.com",
+        "whatsapp.com",
+        "web.whatsapp.com",
+        "www.messenger.com",
+        "messenger.com"
       ]
     }
   }

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -1,9 +1,9 @@
-- id: YOUTUBE_ENHANCE_3_72
+- id: YOUTUBE_ENHANCE_3_82
   content:
     addon:
       amo_url: https://addons.mozilla.org/firefox/addon/enhancer-for-youtube/
       author: Maxime RF
-      icon: resource://activity-stream/data/content/assets/cfr_enhancer_youtube.png
+      icon: chrome://activity-stream/content/data/content/assets/cfr_enhancer_youtube.png
       id: '700308'
       rating: "4.7"
       title: "Enhancer for YouTube\u2122"
@@ -51,19 +51,19 @@
     ,\"iridium@particlecore.github.io\",\"jid1-ss6kLNCbNz6u0g@jetpack\",\"{1cf918d2-f4ea-4b4f-b34e-455283fef19f}\"\
     ] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.youtube.com\"\
     ,\"youtube.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length\
-    \ > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons"
+    \ > 0 && firefoxVersion >= 82 && userPrefs.cfrAddons"
   template: cfr_doorhanger
   trigger:
     id: openURL
     params:
       - www.youtube.com
       - youtube.com
-- id: GOOGLE_TRANSLATE_3_72
+- id: GOOGLE_TRANSLATE_3_82
   content:
     addon:
       amo_url: https://addons.mozilla.org/firefox/addon/to-google-translate/
       author: Juan Escobar
-      icon: resource://activity-stream/data/content/assets/cfr_google_translate.png
+      icon: chrome://activity-stream/content/data/content/assets/cfr_google_translate.png
       id: '445852'
       rating: "4.1"
       title: To Google Translate
@@ -116,18 +116,18 @@
     ,\"{e20e0de5-1667-4df4-bd69-705720e37391}\",\"{09e26ae9-e9c1-477c-80a6-99934212f2fe}\"\
     ,\"mgxtranslator@magemagix.com\",\"gtranslatewins@mozilla.org\"] intersect addonsInfo.addons|keys)|length\
     \ == 0 &&\n      ([\"translate.google.com\"] intersect topFrecentSites[.frecency\
-    \ >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons"
+    \ >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 82 && userPrefs.cfrAddons"
   template: cfr_doorhanger
   trigger:
     id: openURL
     params:
       - translate.google.com
-- id: FACEBOOK_CONTAINER_3_72
+- id: FACEBOOK_CONTAINER_3_82
   content:
     addon:
       amo_url: https://addons.mozilla.org/firefox/addon/facebook-container/
       author: Mozilla
-      icon: resource://activity-stream/data/content/assets/cfr_fb_container.png
+      icon: chrome://activity-stream/content/data/content/assets/cfr_fb_container.png
       id: '954390'
       rating: "4.4"
       title: Facebook Container
@@ -173,7 +173,7 @@
     ,\"{a50d61ca-d27b-437a-8b52-5fd801a0a88b}\"] intersect addonsInfo.addons|keys)|length\
     \ == 0 &&\n      ([\"www.facebook.com\",\"facebook.com\",\"messenger.com\",\"www.messenger.com\",\
     \"instagram.com\",\"www.instagram.com\",\"whatsapp.com\",\"www.whatsapp.com\",\"web.whatsapp.com\"]\
-    intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && userPrefs.cfrAddons"
+    intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && userPrefs.cfrAddons && firefoxVersion >= 82"
   template: cfr_doorhanger
   trigger:
     id: openURL
@@ -796,8 +796,7 @@
       string_id: cfr-doorhanger-sync-logins-body
   frequency:
     lifetime: 3
-  targeting: (!type || type == 'save') && isFxAEnabled == true && usesFirefoxSync == false && firefoxVersion >=
-    72
+  targeting: (!type || type == 'save') && isFxAEnabled == true && usesFirefoxSync == false && firefoxVersion >= 72
   template: cfr_doorhanger
   trigger:
     id: newSavedLogin
@@ -842,8 +841,7 @@
       string_id: cfr-doorhanger-sync-logins-body
   frequency:
     lifetime: 3
-  targeting: type == 'update' && isFxAEnabled == true && usesFirefoxSync == false && firefoxVersion >=
-    76
+  targeting: type == 'update' && isFxAEnabled == true && usesFirefoxSync == false && firefoxVersion >= 76
   template: cfr_doorhanger
   trigger:
     id: newSavedLogin
@@ -1029,3 +1027,192 @@
     id: openURL
     patterns:
       - "*://*/*"
+- id: YOUTUBE_ENHANCE_3_72
+  content:
+    addon:
+      amo_url: https://addons.mozilla.org/firefox/addon/enhancer-for-youtube/
+      author: Maxime RF
+      icon: resource://activity-stream/data/content/assets/cfr_enhancer_youtube.png
+      id: '700308'
+      rating: "4.7"
+      title: "Enhancer for YouTube\u2122"
+      users: 807032
+    bucket_id: CFR_M1
+    buttons:
+      primary:
+        action:
+          data:
+            url: null
+          type: INSTALL_ADDON_FROM_URL
+        label:
+          string_id: cfr-doorhanger-extension-ok-button
+      secondary:
+        - action:
+            type: CANCEL
+          label:
+            string_id: cfr-doorhanger-extension-cancel-button
+        - label:
+            string_id: cfr-doorhanger-extension-never-show-recommendation
+        - action:
+            data:
+              category: general-cfraddons
+              origin: CFR
+            type: OPEN_PREFERENCES_PAGE
+          label:
+            string_id: cfr-doorhanger-extension-manage-settings-button
+    category: cfrAddons
+    heading_text:
+      string_id: cfr-doorhanger-extension-heading
+    info_icon:
+      label:
+        string_id: cfr-doorhanger-extension-sumo-link
+      sumo_path: extensionrecommendations
+    layout: addon_recommendation
+    notification_text:
+      string_id: cfr-doorhanger-extension-notification2
+    text: Take control of your YouTube experience. Automatically block annoying ads,
+      set playback speed and volume, remove annotations, and more.
+  frequency:
+    lifetime: 3
+  targeting: "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled ==\
+    \ true) &&\n      ([\"enhancerforyoutube@maximerf.addons.mozilla.org\",\"{dc8f61ab-5e98-4027-98ef-bb2ff6060d71}\"\
+    ,\"{7b1bf0b6-a1b9-42b0-b75d-252036438bdc}\",\"jid0-UVAeBCfd34Kk5usS8A1CBiobvM8@jetpack\"\
+    ,\"iridium@particlecore.github.io\",\"jid1-ss6kLNCbNz6u0g@jetpack\",\"{1cf918d2-f4ea-4b4f-b34e-455283fef19f}\"\
+    ] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.youtube.com\"\
+    ,\"youtube.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length\
+    \ > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons"
+  template: cfr_doorhanger
+  trigger:
+    id: openURL
+    params:
+      - www.youtube.com
+      - youtube.com
+- id: GOOGLE_TRANSLATE_3_72
+  content:
+    addon:
+      amo_url: https://addons.mozilla.org/firefox/addon/to-google-translate/
+      author: Juan Escobar
+      icon: resource://activity-stream/data/content/assets/cfr_google_translate.png
+      id: '445852'
+      rating: "4.1"
+      title: To Google Translate
+      users: 623523
+    bucket_id: CFR_M1
+    buttons:
+      primary:
+        action:
+          data:
+            url: null
+          type: INSTALL_ADDON_FROM_URL
+        label:
+          string_id: cfr-doorhanger-extension-ok-button
+      secondary:
+        - action:
+            type: CANCEL
+          label:
+            string_id: cfr-doorhanger-extension-cancel-button
+        - label:
+            string_id: cfr-doorhanger-extension-never-show-recommendation
+        - action:
+            data:
+              category: general-cfraddons
+              origin: CFR
+            type: OPEN_PREFERENCES_PAGE
+          label:
+            string_id: cfr-doorhanger-extension-manage-settings-button
+    category: cfrAddons
+    heading_text:
+      string_id: cfr-doorhanger-extension-heading
+    info_icon:
+      label:
+        string_id: cfr-doorhanger-extension-sumo-link
+      sumo_path: extensionrecommendations
+    notification_text:
+      string_id: cfr-doorhanger-extension-notification2
+    text: Instantly translate any webpage text. Simply highlight the text, right-click
+      to open the context menu, and choose a text or aural translation.
+  frequency:
+    lifetime: 3
+  targeting: "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled ==\
+    \ true) &&\n      ([\"jid1-93WyvpgvxzGATw@jetpack\",\"{087ef4e1-4286-4be6-9aa3-8d6c420ee1db}\"\
+    ,\"{4170faaa-ee87-4a0e-b57a-1aec49282887}\",\"jid1-TMndP6cdKgxLcQ@jetpack\",\"\
+    s3google@translator\",\"{9c63d15c-b4d9-43bd-b223-37f0a1f22e2a}\",\"translator@zoli.bod\"\
+    ,\"{8cda9ce6-7893-4f47-ac70-a65215cec288}\",\"simple-translate@sienori\",\"@translatenow\"\
+    ,\"{a79fafce-8da6-4685-923f-7ba1015b8748})\",\"{8a802b5a-eeab-11e2-a41d-b0096288709b}\"\
+    ,\"jid0-fbHwsGfb6kJyq2hj65KnbGte3yT@jetpack\",\"storetranslate.plugin@gmail.com\"\
+    ,\"jid1-r2tWDbSkq8AZK1@jetpack\",\"{b384b75c-c978-4c4d-b3cf-62a82d8f8f12}\",\"\
+    jid1-f7dnBeTj8ElpWQ@jetpack\",\"{dac8a935-4775-4918-9205-5c0600087dc4}\",\"gtranslation2@slam.com\"\
+    ,\"{e20e0de5-1667-4df4-bd69-705720e37391}\",\"{09e26ae9-e9c1-477c-80a6-99934212f2fe}\"\
+    ,\"mgxtranslator@magemagix.com\",\"gtranslatewins@mozilla.org\"] intersect addonsInfo.addons|keys)|length\
+    \ == 0 &&\n      ([\"translate.google.com\"] intersect topFrecentSites[.frecency\
+    \ >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons"
+  template: cfr_doorhanger
+  trigger:
+    id: openURL
+    params:
+      - translate.google.com
+- id: FACEBOOK_CONTAINER_3_72
+  content:
+    addon:
+      amo_url: https://addons.mozilla.org/firefox/addon/facebook-container/
+      author: Mozilla
+      icon: resource://activity-stream/data/content/assets/cfr_fb_container.png
+      id: '954390'
+      rating: "4.4"
+      title: Facebook Container
+      users: 1455872
+    bucket_id: CFR_M1
+    buttons:
+      primary:
+        action:
+          data:
+            url: null
+          type: INSTALL_ADDON_FROM_URL
+        label:
+          string_id: cfr-doorhanger-extension-ok-button
+      secondary:
+        - action:
+            type: CANCEL
+          label:
+            string_id: cfr-doorhanger-extension-cancel-button
+        - label:
+            string_id: cfr-doorhanger-extension-never-show-recommendation
+        - action:
+            data:
+              category: general-cfraddons
+              origin: CFR
+            type: OPEN_PREFERENCES_PAGE
+          label:
+            string_id: cfr-doorhanger-extension-manage-settings-button
+    category: cfrAddons
+    heading_text:
+      string_id: cfr-doorhanger-extension-heading
+    info_icon:
+      label:
+        string_id: cfr-doorhanger-extension-sumo-link
+      sumo_path: extensionrecommendations
+    notification_text:
+      string_id: cfr-doorhanger-extension-notification2
+    text: Stop Facebook from tracking your activity across the web. Use Facebook the
+      way you normally do without annoying ads following you around.
+  frequency:
+    lifetime: 3
+  targeting: "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled ==\
+    \ true) &&\n      ([\"@contain-facebook\",\"{bb1b80be-e6b3-40a1-9b6e-9d4073343f0b}\"\
+    ,\"{a50d61ca-d27b-437a-8b52-5fd801a0a88b}\"] intersect addonsInfo.addons|keys)|length\
+    \ == 0 &&\n      ([\"www.facebook.com\",\"facebook.com\",\"messenger.com\",\"www.messenger.com\",\
+    \"instagram.com\",\"www.instagram.com\",\"whatsapp.com\",\"www.whatsapp.com\",\"web.whatsapp.com\"]\
+    intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons"
+  template: cfr_doorhanger
+  trigger:
+    id: openURL
+    params:
+      - www.facebook.com
+      - facebook.com
+      - www.instagram.com
+      - instagram.com
+      - www.whatsapp.com
+      - whatsapp.com
+      - web.whatsapp.com
+      - www.messenger.com
+      - messenger.com


### PR DESCRIPTION
We need to duplicate the messages because of the different URL schema (pre 82 / post 82).

Funny enough this happened exactly 10 version ago for a different (but similar) reason.