### PR TITLE
Exchanging buttons for Fission Experiment

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -1397,23 +1397,23 @@
         "secondary": [
           {
             "action": {
-              "type": "OPEN_URL",
-              "data": {
-                "args": "https://wiki.mozilla.org/Project_Fission",
-                "where": "tabshifted"
-              }
+              "type": "CANCEL"
             },
             "label": {
-              "string_id": "cfr-doorhanger-fission-secondary-button"
+              "string_id": "cfr-doorhanger-fission-primary-button"
             }
           }
         ],
         "primary": {
-          "label": {
-            "string_id": "cfr-doorhanger-fission-primary-button"
-          },
           "action": {
-            "type": "CANCEL"
+            "type": "OPEN_URL",
+            "data": {
+              "args": "https://wiki.mozilla.org/Project_Fission",
+              "where": "tabshifted"
+            }
+          },
+          "label": {
+            "string_id": "cfr-doorhanger-fission-secondary-button"
           }
         }
       },

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -1048,17 +1048,17 @@
     buttons:
       secondary:
         - action:
-            type: OPEN_URL
-            data:
-              args: https://wiki.mozilla.org/Project_Fission
-              where: tabshifted
+            type: CANCEL
           label:
-            string_id: cfr-doorhanger-fission-secondary-button
+            string_id: cfr-doorhanger-fission-primary-button
       primary:
-        label:
-          string_id: cfr-doorhanger-fission-primary-button
         action:
-          type: CANCEL
+          type: OPEN_URL
+          data:
+            args: https://wiki.mozilla.org/Project_Fission
+            where: tabshifted
+        label:
+          string_id: cfr-doorhanger-fission-secondary-button
     heading_text:
       string_id: cfr-doorhanger-fission-header
     notification_text:


### PR DESCRIPTION
Unfortunately, this has the side-effect of setting the primary button's label with
`cfr-doorhanger-fission-secondary-button` and the primary with `cfr-doorhanger-fission-primary-button`.

If that's a problem, I'll switch the names here and on mozilla-central.