### PR TITLE
Validate message ID for CFR experiment

### DIFF
--- a/archive/messaging-experiments-archived.yaml
+++ b/archive/messaging-experiments-archived.yaml
@@ -2625,3 +2625,37 @@
                   label: Start Browsing
                   action:
                     navigate: true
+- id: XMAN-MOMENTS-PAGE-80-NIGHTLY
+  # Do *not* publish to production. This message is used for dev and QA only
+  enabled: true
+  filter_expression: env.version >= '80.' && env.version < '81.' && (env.channel == 'nightly' || env.channel == 'default')
+  targeting: localeLanguageCode == "en"
+  arguments:
+    slug: xman-moments-page-80-nightly
+    userFacingName: "Moments Page Test: Nightly 80"
+    userFacingDescription: "Moments page test"
+    isEnrollmentPaused: false
+    branches:
+      - slug: control
+        ratio: 1
+        groups:
+          - moments-page
+        value: {}
+      - slug: treatment
+        ratio: 1
+        groups:
+          - moments-page
+        value:
+          id: XMAN_MOMENTS_TEST
+          groups: [moments-pages]
+          content:
+            action:
+              data:
+                expireDelta: 604800000
+                url: https://www.mozilla.org/firefox/welcome/1/
+              id: moments-wnp
+            bucket_id: XMAN_MOMENTS_TEST
+          targeting: "true"
+          template: update_action
+          trigger:
+            id: momentsUpdate

--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -14,7 +14,7 @@
         "slug": "control",
         "ratio": 1,
         "feature": {
-          "featureId": "aboutwelcome",
+          "featureId": "cfr",
           "enabled": true,
           "value": null
         }
@@ -23,10 +23,58 @@
         "slug": "treatment",
         "ratio": 1,
         "feature": {
-          "featureId": "aboutwelcome",
+          "featureId": "cfr",
           "enabled": true,
           "value": {
-            "title": "hello"
+            "id": "TEST-EXPERIMENT-82:treatment",
+            "content": {
+              "bucket_id": "TEST-EXPERIMENT-82:treatment",
+              "category": "cfrFeatures",
+              "buttons": {
+                "primary": {
+                  "action": {
+                    "data": {
+                      "args": "pageAction-sendToDevice"
+                    },
+                    "type": "HIGHLIGHT_FEATURE"
+                  },
+                  "label": {
+                    "string_id": "cfr-doorhanger-send-tab-ok-button"
+                  }
+                },
+                "secondary": [
+                  {
+                    "action": {
+                      "type": "CANCEL"
+                    },
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-cancel-button"
+                    }
+                  },
+                  {
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-never-show-recommendation"
+                    }
+                  },
+                  {
+                    "action": {
+                      "data": {
+                        "category": "general-cfrfeatures"
+                      },
+                      "type": "OPEN_PREFERENCES_PAGE"
+                    },
+                    "label": {
+                      "string_id": "cfr-doorhanger-extension-manage-settings-button"
+                    }
+                  }
+                ]
+              }
+            },
+            "targeting": "locale == en-US",
+            "template": "cfr_doorhanger",
+            "trigger": {
+              "id": "openArticleURL"
+            }
           }
         }
       }

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -11,16 +11,44 @@
     - slug: control
       ratio: 1
       feature:
-        featureId: aboutwelcome
+        featureId: cfr
         enabled: true
         value:
     - slug: treatment
       ratio: 1
       feature:
-        featureId: aboutwelcome
+        featureId: cfr
         enabled: true
         value:
-          title: hello
+          id: "TEST-EXPERIMENT-82:treatment"
+          content:
+            bucket_id: "TEST-EXPERIMENT-82:treatment"
+            category: cfrFeatures
+            buttons:
+              primary:
+                action:
+                  data:
+                    args: pageAction-sendToDevice
+                  type: HIGHLIGHT_FEATURE
+                label:
+                  string_id: cfr-doorhanger-send-tab-ok-button
+              secondary:
+                - action:
+                    type: CANCEL
+                  label:
+                    string_id: cfr-doorhanger-extension-cancel-button
+                - label:
+                    string_id: cfr-doorhanger-extension-never-show-recommendation
+                - action:
+                    data:
+                      category: general-cfrfeatures
+                    type: OPEN_PREFERENCES_PAGE
+                  label:
+                    string_id: cfr-doorhanger-extension-manage-settings-button
+          targeting: "locale == en-US"
+          template: cfr_doorhanger
+          trigger:
+            id: openArticleURL
   bucketConfig:
     namespace: messaging-system-inflight-assets
     randomizationUnit: normandy_id

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -142,7 +142,7 @@ def get_branch_message(branch):
     feature_id = feature["featureId"]
     if feature_id == "cfr":
         value = feature["value"]
-        if "id" in value:
+        if value is not None and "id" in value:
             return "cfr", feature["value"]
         return "cfr", None
     elif feature_id == "aboutwelcome":
@@ -200,7 +200,7 @@ def validate_experiment(item):
                     branch_message]
             for message in branch_message_list:
                 jsonschema.validate(instance=message, schema=schema)
-            print("\tValidated {} with schema {}".format(
+            print("\tValidate {} with schema {}".format(
                 branch.get("slug"), message_type))
         except ValidationError as err:
             match = best_match([err])
@@ -214,7 +214,7 @@ def validate_experiment(item):
         validate_all_actions(branch_message, message_type, True)
 
         # Validate the message_id naming
-        validate_experiment_message_id(item.slug, branch)
+        validate_experiment_message_id(item["slug"], branch)
 
 
 def validate(schema_name, src_path):


### PR DESCRIPTION
This fixes #159.

@piatra Yet another tape on the duct :P.

Note that this only enforces the message_id for CFR experiments. I've also deleted the recipe for Moments page so that we can clean up the validation script a bit.