### PR TITLE
Specify group configuration for all CFR messages. Follow up to bug 1652513

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -1,6 +1,9 @@
 [
   {
     "id": "MILESTONE_MESSAGE",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "anchor_id": "tracking-protection-icon-box",
       "bucket_id": "CFR_MILESTONE_MESSAGE",
@@ -38,6 +41,9 @@
   },
   {
     "id": "SEND_TAB_CFR",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "bucket_id": "SEND_TAB_CFR",
       "buttons": {
@@ -203,6 +209,9 @@
   },
   {
     "id": "SEND_RECIPE_TAB_CFR",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "bucket_id": "SEND_RECIPE_TAB_CFR",
       "buttons": {
@@ -511,6 +520,9 @@
   },
   {
     "id": "BOOKMARK_SYNC_CFR",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "bucket_id": "BOOKMARK_SYNC_CFR",
       "buttons": {
@@ -583,6 +595,9 @@
   },
   {
     "id": "PIN_TAB_72",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "bucket_id": "CFR_PIN_TAB",
       "buttons": {
@@ -700,6 +715,9 @@
   },
   {
     "id": "SAVE_LOGIN_72",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "bucket_id": "CFR_SAVE_LOGIN",
       "buttons": {
@@ -773,6 +791,9 @@
   },
   {
     "id": "UPDATE_LOGIN",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "bucket_id": "CFR_UPDATE_LOGIN",
       "buttons": {
@@ -846,6 +867,9 @@
   },
   {
     "id": "SOCIAL_TRACKING_PROTECTION",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "anchor_id": "tracking-protection-icon-box",
       "bucket_id": "CFR_SOCIAL_TRACKING_PROTECTION",
@@ -920,6 +944,9 @@
   },
   {
     "id": "FINGERPRINTERS_PROTECTION",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "anchor_id": "tracking-protection-icon-box",
       "bucket_id": "CFR_FINGERPRINTERS_PROTECTION",
@@ -993,6 +1020,9 @@
   },
   {
     "id": "CRYPTOMINERS_PROTECTION",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "anchor_id": "tracking-protection-icon-box",
       "bucket_id": "CFR_CRYPTOMINERS_PROTECTION",
@@ -1066,6 +1096,9 @@
   },
   {
     "id": "DOH_ROLLOUT_CONFIRMATION",
+    "groups": [
+      "cfr"
+    ],
     "targeting": "'doh-rollout.enabled'|preferenceValue && !'doh-rollout.disable-heuristics'|preferenceValue && !'doh-rollout.skipHeuristicsCheck'|preferenceValue && !'doh-rollout.doorhanger-decision'|preferenceValue && firefoxVersion >= 79",
     "template": "cfr_doorhanger",
     "content": {
@@ -1122,6 +1155,9 @@
   },
   {
     "id": "YOUTUBE_ENHANCE_3_72",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "addon": {
         "amo_url": "https://addons.mozilla.org/firefox/addon/enhancer-for-youtube/",
@@ -1204,6 +1240,9 @@
   },
   {
     "id": "GOOGLE_TRANSLATE_3_72",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "addon": {
         "amo_url": "https://addons.mozilla.org/firefox/addon/to-google-translate/",
@@ -1284,6 +1323,9 @@
   },
   {
     "id": "FACEBOOK_CONTAINER_3_72",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "addon": {
         "amo_url": "https://addons.mozilla.org/firefox/addon/facebook-container/",
@@ -1372,6 +1414,9 @@
   },
   {
     "id": "FISSION_EXPERIMENT_CONFIRMATION",
+    "groups": [
+      "cfr"
+    ],
     "targeting": "isFissionExperimentEnabled",
     "frequency": {
       "lifetime": 1

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -1,4 +1,6 @@
 - id: MILESTONE_MESSAGE
+  groups:
+    - cfr
   content:
     anchor_id: tracking-protection-icon-box
     bucket_id: CFR_MILESTONE_MESSAGE
@@ -25,6 +27,8 @@
     params:
       - ContentBlockingMilestone
 - id: SEND_TAB_CFR
+  groups:
+    - cfr
   content:
     bucket_id: SEND_TAB_CFR
     buttons:
@@ -161,6 +165,8 @@
       - bleacherreport.com
       - www.bleacherreport.com
 - id: SEND_RECIPE_TAB_CFR
+  groups:
+    - cfr
   content:
     bucket_id: SEND_RECIPE_TAB_CFR
     buttons:
@@ -440,6 +446,8 @@
       - kraftrecipes.com
       - www.kraftrecipes.com
 - id: BOOKMARK_SYNC_CFR
+  groups:
+    - cfr
   content:
     bucket_id: BOOKMARK_SYNC_CFR
     buttons:
@@ -484,6 +492,8 @@
   trigger:
     id: openBookmarkedURL
 - id: PIN_TAB_72
+  groups:
+    - cfr
   content:
     bucket_id: CFR_PIN_TAB
     buttons:
@@ -567,6 +577,8 @@
       - amazon.de
       - www.amazon.de
 - id: SAVE_LOGIN_72
+  groups:
+    - cfr
   content:
     bucket_id: CFR_SAVE_LOGIN
     buttons:
@@ -612,6 +624,8 @@
   trigger:
     id: newSavedLogin
 - id: UPDATE_LOGIN
+  groups:
+    - cfr
   content:
     bucket_id: CFR_UPDATE_LOGIN
     buttons:
@@ -657,6 +671,8 @@
   trigger:
     id: newSavedLogin
 - id: SOCIAL_TRACKING_PROTECTION
+  groups:
+    - cfr
   content:
     anchor_id: tracking-protection-icon-box
     bucket_id: CFR_SOCIAL_TRACKING_PROTECTION
@@ -706,6 +722,8 @@
       - 65536
       - 537001984
 - id: FINGERPRINTERS_PROTECTION
+  groups:
+    - cfr
   content:
     anchor_id: tracking-protection-icon-box
     bucket_id: CFR_FINGERPRINTERS_PROTECTION
@@ -754,6 +772,8 @@
     params:
       - 64
 - id: CRYPTOMINERS_PROTECTION
+  groups:
+    - cfr
   content:
     anchor_id: tracking-protection-icon-box
     bucket_id: CFR_CRYPTOMINERS_PROTECTION
@@ -802,6 +822,8 @@
     params:
       - 2048
 - id: DOH_ROLLOUT_CONFIRMATION
+  groups:
+    - cfr
   targeting: "'doh-rollout.enabled'|preferenceValue && !'doh-rollout.disable-heuristics'|preferenceValue && !'doh-rollout.skipHeuristicsCheck'|preferenceValue && !'doh-rollout.doorhanger-decision'|preferenceValue && firefoxVersion >= 79"
   template: cfr_doorhanger
   content:
@@ -839,6 +861,8 @@
     patterns:
       - "*://*/*"
 - id: YOUTUBE_ENHANCE_3_72
+  groups:
+    - cfr
   content:
     addon:
       amo_url: https://addons.mozilla.org/firefox/addon/enhancer-for-youtube/
@@ -899,6 +923,8 @@
       - www.youtube.com
       - youtube.com
 - id: GOOGLE_TRANSLATE_3_72
+  groups:
+    - cfr
   content:
     addon:
       amo_url: https://addons.mozilla.org/firefox/addon/to-google-translate/
@@ -963,6 +989,8 @@
     params:
       - translate.google.com
 - id: FACEBOOK_CONTAINER_3_72
+  groups:
+    - cfr
   content:
     addon:
       amo_url: https://addons.mozilla.org/firefox/addon/facebook-container/
@@ -1028,6 +1056,8 @@
       - www.messenger.com
       - messenger.com
 - id: FISSION_EXPERIMENT_CONFIRMATION
+  groups:
+    - cfr
   targeting: "isFissionExperimentEnabled"
   frequency:
     lifetime: 1

--- a/messaging-experiments-82.json
+++ b/messaging-experiments-82.json
@@ -31,6 +31,9 @@
               "group": [
                 "cfr"
               ],
+              "groups": [
+                "cfr-experiments"
+              ],
               "frequency": {
                 "lifetime": 3
               },
@@ -124,6 +127,9 @@
               "group": [
                 "cfr"
               ],
+              "groups": [
+                "cfr-experiments"
+              ],
               "frequency": {
                 "lifetime": 3
               },
@@ -216,6 +222,9 @@
               "id": "bug-1661707-homepage-remediation-search-value:treatment-c",
               "group": [
                 "cfr"
+              ],
+              "groups": [
+                "cfr-experiments"
               ],
               "frequency": {
                 "lifetime": 3

--- a/messaging-experiments-82.yaml
+++ b/messaging-experiments-82.yaml
@@ -29,6 +29,10 @@
             # Workaround for bug 1671149
             group:
               - cfr
+            # This links the message with the daily group frequency cap defined
+            # here: https://github.com/mozilla/messaging-system-inflight-assets/blob/3b9db1ec2c437c4c954213ac11a457264c3492e3/message-groups.json#L16
+            groups:
+              - cfr-experiments
             frequency:
               lifetime: 3
             # Has google set as the homepage, has CFR features enabled, has profile
@@ -93,6 +97,10 @@
             # Workaround for bug 1671149
             group:
               - cfr
+            # This links the message with the daily group frequency cap defined
+            # here: https://github.com/mozilla/messaging-system-inflight-assets/blob/3b9db1ec2c437c4c954213ac11a457264c3492e3/message-groups.json#L16
+            groups:
+              - cfr-experiments
             frequency:
               lifetime: 3
             # Has google set as the homepage, has CFR features enabled, has profile
@@ -157,6 +165,10 @@
             # Workaround for bug 1671149
             group:
               - cfr
+            # This links the message with the daily group frequency cap defined
+            # here: https://github.com/mozilla/messaging-system-inflight-assets/blob/3b9db1ec2c437c4c954213ac11a457264c3492e3/message-groups.json#L16
+            groups:
+              - cfr-experiments
             frequency:
               lifetime: 3
             # Has google set as the homepage, has CFR features enabled, has profile

--- a/messaging-experiments.json
+++ b/messaging-experiments.json
@@ -27,6 +27,9 @@
           "enabled": true,
           "value": {
             "id": "TEST-EXPERIMENT-82:treatment",
+            "groups": [
+              "cfr-experiments"
+            ],
             "content": {
               "bucket_id": "TEST-EXPERIMENT-82:treatment",
               "category": "cfrFeatures",

--- a/messaging-experiments.yaml
+++ b/messaging-experiments.yaml
@@ -21,6 +21,8 @@
         enabled: true
         value:
           id: "TEST-EXPERIMENT-82:treatment"
+          groups:
+            - cfr-experiments
           content:
             bucket_id: "TEST-EXPERIMENT-82:treatment"
             category: cfrFeatures

--- a/schema/cfr.schema.json
+++ b/schema/cfr.schema.json
@@ -456,5 +456,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["id", "content", "targeting", "template", "trigger"]
+  "required": ["id", "groups", "content", "targeting", "template", "trigger"]
 }


### PR DESCRIPTION
While testing the Homepage remediation recipe QA flagged the missing daily frequency cap.
I realized that following 1652513 we no longer have default group configurations for messages (this allows us to reuse RS buckets for different purposes) but now messages require `groups` in order to prevent overlap and showing multiple ones in a day.