### PR TITLE
Update the icon paths for CFR messages

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -1228,7 +1228,7 @@
     "frequency": {
       "lifetime": 3
     },
-    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"enhancerforyoutube@maximerf.addons.mozilla.org\",\"{dc8f61ab-5e98-4027-98ef-bb2ff6060d71}\",\"{7b1bf0b6-a1b9-42b0-b75d-252036438bdc}\",\"jid0-UVAeBCfd34Kk5usS8A1CBiobvM8@jetpack\",\"iridium@particlecore.github.io\",\"jid1-ss6kLNCbNz6u0g@jetpack\",\"{1cf918d2-f4ea-4b4f-b34e-455283fef19f}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.youtube.com\",\"youtube.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons",
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"enhancerforyoutube@maximerf.addons.mozilla.org\",\"{dc8f61ab-5e98-4027-98ef-bb2ff6060d71}\",\"{7b1bf0b6-a1b9-42b0-b75d-252036438bdc}\",\"jid0-UVAeBCfd34Kk5usS8A1CBiobvM8@jetpack\",\"iridium@particlecore.github.io\",\"jid1-ss6kLNCbNz6u0g@jetpack\",\"{1cf918d2-f4ea-4b4f-b34e-455283fef19f}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.youtube.com\",\"youtube.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons",
     "template": "cfr_doorhanger",
     "trigger": {
       "id": "openURL",
@@ -1312,7 +1312,7 @@
     "frequency": {
       "lifetime": 3
     },
-    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"jid1-93WyvpgvxzGATw@jetpack\",\"{087ef4e1-4286-4be6-9aa3-8d6c420ee1db}\",\"{4170faaa-ee87-4a0e-b57a-1aec49282887}\",\"jid1-TMndP6cdKgxLcQ@jetpack\",\"s3google@translator\",\"{9c63d15c-b4d9-43bd-b223-37f0a1f22e2a}\",\"translator@zoli.bod\",\"{8cda9ce6-7893-4f47-ac70-a65215cec288}\",\"simple-translate@sienori\",\"@translatenow\",\"{a79fafce-8da6-4685-923f-7ba1015b8748})\",\"{8a802b5a-eeab-11e2-a41d-b0096288709b}\",\"jid0-fbHwsGfb6kJyq2hj65KnbGte3yT@jetpack\",\"storetranslate.plugin@gmail.com\",\"jid1-r2tWDbSkq8AZK1@jetpack\",\"{b384b75c-c978-4c4d-b3cf-62a82d8f8f12}\",\"jid1-f7dnBeTj8ElpWQ@jetpack\",\"{dac8a935-4775-4918-9205-5c0600087dc4}\",\"gtranslation2@slam.com\",\"{e20e0de5-1667-4df4-bd69-705720e37391}\",\"{09e26ae9-e9c1-477c-80a6-99934212f2fe}\",\"mgxtranslator@magemagix.com\",\"gtranslatewins@mozilla.org\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"translate.google.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons",
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"jid1-93WyvpgvxzGATw@jetpack\",\"{087ef4e1-4286-4be6-9aa3-8d6c420ee1db}\",\"{4170faaa-ee87-4a0e-b57a-1aec49282887}\",\"jid1-TMndP6cdKgxLcQ@jetpack\",\"s3google@translator\",\"{9c63d15c-b4d9-43bd-b223-37f0a1f22e2a}\",\"translator@zoli.bod\",\"{8cda9ce6-7893-4f47-ac70-a65215cec288}\",\"simple-translate@sienori\",\"@translatenow\",\"{a79fafce-8da6-4685-923f-7ba1015b8748})\",\"{8a802b5a-eeab-11e2-a41d-b0096288709b}\",\"jid0-fbHwsGfb6kJyq2hj65KnbGte3yT@jetpack\",\"storetranslate.plugin@gmail.com\",\"jid1-r2tWDbSkq8AZK1@jetpack\",\"{b384b75c-c978-4c4d-b3cf-62a82d8f8f12}\",\"jid1-f7dnBeTj8ElpWQ@jetpack\",\"{dac8a935-4775-4918-9205-5c0600087dc4}\",\"gtranslation2@slam.com\",\"{e20e0de5-1667-4df4-bd69-705720e37391}\",\"{09e26ae9-e9c1-477c-80a6-99934212f2fe}\",\"mgxtranslator@magemagix.com\",\"gtranslatewins@mozilla.org\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"translate.google.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons",
     "template": "cfr_doorhanger",
     "trigger": {
       "id": "openURL",
@@ -1395,7 +1395,7 @@
     "frequency": {
       "lifetime": 3
     },
-    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"@contain-facebook\",\"{bb1b80be-e6b3-40a1-9b6e-9d4073343f0b}\",\"{a50d61ca-d27b-437a-8b52-5fd801a0a88b}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.facebook.com\",\"facebook.com\",\"messenger.com\",\"www.messenger.com\",\"instagram.com\",\"www.instagram.com\",\"whatsapp.com\",\"www.whatsapp.com\",\"web.whatsapp.com\"]intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons",
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"@contain-facebook\",\"{bb1b80be-e6b3-40a1-9b6e-9d4073343f0b}\",\"{a50d61ca-d27b-437a-8b52-5fd801a0a88b}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.facebook.com\",\"facebook.com\",\"messenger.com\",\"www.messenger.com\",\"instagram.com\",\"www.instagram.com\",\"whatsapp.com\",\"www.whatsapp.com\",\"web.whatsapp.com\"]intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons",
     "template": "cfr_doorhanger",
     "trigger": {
       "id": "openURL",

--- a/cfr.json
+++ b/cfr.json
@@ -1228,7 +1228,7 @@
     "frequency": {
       "lifetime": 3
     },
-    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"enhancerforyoutube@maximerf.addons.mozilla.org\",\"{dc8f61ab-5e98-4027-98ef-bb2ff6060d71}\",\"{7b1bf0b6-a1b9-42b0-b75d-252036438bdc}\",\"jid0-UVAeBCfd34Kk5usS8A1CBiobvM8@jetpack\",\"iridium@particlecore.github.io\",\"jid1-ss6kLNCbNz6u0g@jetpack\",\"{1cf918d2-f4ea-4b4f-b34e-455283fef19f}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.youtube.com\",\"youtube.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons",
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"enhancerforyoutube@maximerf.addons.mozilla.org\",\"{dc8f61ab-5e98-4027-98ef-bb2ff6060d71}\",\"{7b1bf0b6-a1b9-42b0-b75d-252036438bdc}\",\"jid0-UVAeBCfd34Kk5usS8A1CBiobvM8@jetpack\",\"iridium@particlecore.github.io\",\"jid1-ss6kLNCbNz6u0g@jetpack\",\"{1cf918d2-f4ea-4b4f-b34e-455283fef19f}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.youtube.com\",\"youtube.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 82 && userPrefs.cfrAddons",
     "template": "cfr_doorhanger",
     "trigger": {
       "id": "openURL",
@@ -1312,7 +1312,7 @@
     "frequency": {
       "lifetime": 3
     },
-    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"jid1-93WyvpgvxzGATw@jetpack\",\"{087ef4e1-4286-4be6-9aa3-8d6c420ee1db}\",\"{4170faaa-ee87-4a0e-b57a-1aec49282887}\",\"jid1-TMndP6cdKgxLcQ@jetpack\",\"s3google@translator\",\"{9c63d15c-b4d9-43bd-b223-37f0a1f22e2a}\",\"translator@zoli.bod\",\"{8cda9ce6-7893-4f47-ac70-a65215cec288}\",\"simple-translate@sienori\",\"@translatenow\",\"{a79fafce-8da6-4685-923f-7ba1015b8748})\",\"{8a802b5a-eeab-11e2-a41d-b0096288709b}\",\"jid0-fbHwsGfb6kJyq2hj65KnbGte3yT@jetpack\",\"storetranslate.plugin@gmail.com\",\"jid1-r2tWDbSkq8AZK1@jetpack\",\"{b384b75c-c978-4c4d-b3cf-62a82d8f8f12}\",\"jid1-f7dnBeTj8ElpWQ@jetpack\",\"{dac8a935-4775-4918-9205-5c0600087dc4}\",\"gtranslation2@slam.com\",\"{e20e0de5-1667-4df4-bd69-705720e37391}\",\"{09e26ae9-e9c1-477c-80a6-99934212f2fe}\",\"mgxtranslator@magemagix.com\",\"gtranslatewins@mozilla.org\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"translate.google.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons",
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"jid1-93WyvpgvxzGATw@jetpack\",\"{087ef4e1-4286-4be6-9aa3-8d6c420ee1db}\",\"{4170faaa-ee87-4a0e-b57a-1aec49282887}\",\"jid1-TMndP6cdKgxLcQ@jetpack\",\"s3google@translator\",\"{9c63d15c-b4d9-43bd-b223-37f0a1f22e2a}\",\"translator@zoli.bod\",\"{8cda9ce6-7893-4f47-ac70-a65215cec288}\",\"simple-translate@sienori\",\"@translatenow\",\"{a79fafce-8da6-4685-923f-7ba1015b8748})\",\"{8a802b5a-eeab-11e2-a41d-b0096288709b}\",\"jid0-fbHwsGfb6kJyq2hj65KnbGte3yT@jetpack\",\"storetranslate.plugin@gmail.com\",\"jid1-r2tWDbSkq8AZK1@jetpack\",\"{b384b75c-c978-4c4d-b3cf-62a82d8f8f12}\",\"jid1-f7dnBeTj8ElpWQ@jetpack\",\"{dac8a935-4775-4918-9205-5c0600087dc4}\",\"gtranslation2@slam.com\",\"{e20e0de5-1667-4df4-bd69-705720e37391}\",\"{09e26ae9-e9c1-477c-80a6-99934212f2fe}\",\"mgxtranslator@magemagix.com\",\"gtranslatewins@mozilla.org\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"translate.google.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 82 && userPrefs.cfrAddons",
     "template": "cfr_doorhanger",
     "trigger": {
       "id": "openURL",
@@ -1395,7 +1395,7 @@
     "frequency": {
       "lifetime": 3
     },
-    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"@contain-facebook\",\"{bb1b80be-e6b3-40a1-9b6e-9d4073343f0b}\",\"{a50d61ca-d27b-437a-8b52-5fd801a0a88b}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.facebook.com\",\"facebook.com\",\"messenger.com\",\"www.messenger.com\",\"instagram.com\",\"www.instagram.com\",\"whatsapp.com\",\"www.whatsapp.com\",\"web.whatsapp.com\"]intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons",
+    "targeting": "\n      localeLanguageCode == \"en\" &&\n      (xpinstallEnabled == true) &&\n      ([\"@contain-facebook\",\"{bb1b80be-e6b3-40a1-9b6e-9d4073343f0b}\",\"{a50d61ca-d27b-437a-8b52-5fd801a0a88b}\"] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.facebook.com\",\"facebook.com\",\"messenger.com\",\"www.messenger.com\",\"instagram.com\",\"www.instagram.com\",\"whatsapp.com\",\"www.whatsapp.com\",\"web.whatsapp.com\"]intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 82 && userPrefs.cfrAddons",
     "template": "cfr_doorhanger",
     "trigger": {
       "id": "openURL",

--- a/cfr.json
+++ b/cfr.json
@@ -1162,7 +1162,7 @@
       "addon": {
         "amo_url": "https://addons.mozilla.org/firefox/addon/enhancer-for-youtube/",
         "author": "Maxime RF",
-        "icon": "resource://activity-stream/data/content/assets/cfr_enhancer_youtube.png",
+        "icon": "chrome://activity-stream/content/data/content/assets/cfr_enhancer_youtube.png",
         "id": "700308",
         "rating": "4.7",
         "title": "Enhancer for YouTube\u2122",
@@ -1247,7 +1247,7 @@
       "addon": {
         "amo_url": "https://addons.mozilla.org/firefox/addon/to-google-translate/",
         "author": "Juan Escobar",
-        "icon": "resource://activity-stream/data/content/assets/cfr_google_translate.png",
+        "icon": "chrome://activity-stream/content/data/content/assets/cfr_google_translate.png",
         "id": "445852",
         "rating": "4.1",
         "title": "To Google Translate",
@@ -1330,7 +1330,7 @@
       "addon": {
         "amo_url": "https://addons.mozilla.org/firefox/addon/facebook-container/",
         "author": "Mozilla",
-        "icon": "resource://activity-stream/data/content/assets/cfr_fb_container.png",
+        "icon": "chrome://activity-stream/content/data/content/assets/cfr_fb_container.png",
         "id": "954390",
         "rating": "4.4",
         "title": "Facebook Container",

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -915,7 +915,7 @@
     ,\"iridium@particlecore.github.io\",\"jid1-ss6kLNCbNz6u0g@jetpack\",\"{1cf918d2-f4ea-4b4f-b34e-455283fef19f}\"\
     ] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.youtube.com\"\
     ,\"youtube.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length\
-    \ > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons"
+    \ > 0 && firefoxVersion >= 82 && userPrefs.cfrAddons"
   template: cfr_doorhanger
   trigger:
     id: openURL
@@ -982,7 +982,7 @@
     ,\"{e20e0de5-1667-4df4-bd69-705720e37391}\",\"{09e26ae9-e9c1-477c-80a6-99934212f2fe}\"\
     ,\"mgxtranslator@magemagix.com\",\"gtranslatewins@mozilla.org\"] intersect addonsInfo.addons|keys)|length\
     \ == 0 &&\n      ([\"translate.google.com\"] intersect topFrecentSites[.frecency\
-    \ >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons"
+    \ >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 82 && userPrefs.cfrAddons"
   template: cfr_doorhanger
   trigger:
     id: openURL
@@ -1041,7 +1041,7 @@
     ,\"{a50d61ca-d27b-437a-8b52-5fd801a0a88b}\"] intersect addonsInfo.addons|keys)|length\
     \ == 0 &&\n      ([\"www.facebook.com\",\"facebook.com\",\"messenger.com\",\"www.messenger.com\",\
     \"instagram.com\",\"www.instagram.com\",\"whatsapp.com\",\"www.whatsapp.com\",\"web.whatsapp.com\"]\
-    intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons"
+    intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 82 && userPrefs.cfrAddons"
   template: cfr_doorhanger
   trigger:
     id: openURL

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -867,7 +867,7 @@
     addon:
       amo_url: https://addons.mozilla.org/firefox/addon/enhancer-for-youtube/
       author: Maxime RF
-      icon: resource://activity-stream/data/content/assets/cfr_enhancer_youtube.png
+      icon: chrome://activity-stream/content/data/content/assets/cfr_enhancer_youtube.png
       id: '700308'
       rating: "4.7"
       title: "Enhancer for YouTube\u2122"
@@ -929,7 +929,7 @@
     addon:
       amo_url: https://addons.mozilla.org/firefox/addon/to-google-translate/
       author: Juan Escobar
-      icon: resource://activity-stream/data/content/assets/cfr_google_translate.png
+      icon: chrome://activity-stream/content/data/content/assets/cfr_google_translate.png
       id: '445852'
       rating: "4.1"
       title: To Google Translate
@@ -995,7 +995,7 @@
     addon:
       amo_url: https://addons.mozilla.org/firefox/addon/facebook-container/
       author: Mozilla
-      icon: resource://activity-stream/data/content/assets/cfr_fb_container.png
+      icon: chrome://activity-stream/content/data/content/assets/cfr_fb_container.png
       id: '954390'
       rating: "4.4"
       title: Facebook Container

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -915,7 +915,7 @@
     ,\"iridium@particlecore.github.io\",\"jid1-ss6kLNCbNz6u0g@jetpack\",\"{1cf918d2-f4ea-4b4f-b34e-455283fef19f}\"\
     ] intersect addonsInfo.addons|keys)|length == 0 &&\n      ([\"www.youtube.com\"\
     ,\"youtube.com\"] intersect topFrecentSites[.frecency >= 10000]|mapToProperty('host'))|length\
-    \ > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons"
+    \ > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons"
   template: cfr_doorhanger
   trigger:
     id: openURL
@@ -982,7 +982,7 @@
     ,\"{e20e0de5-1667-4df4-bd69-705720e37391}\",\"{09e26ae9-e9c1-477c-80a6-99934212f2fe}\"\
     ,\"mgxtranslator@magemagix.com\",\"gtranslatewins@mozilla.org\"] intersect addonsInfo.addons|keys)|length\
     \ == 0 &&\n      ([\"translate.google.com\"] intersect topFrecentSites[.frecency\
-    \ >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons"
+    \ >= 10000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons"
   template: cfr_doorhanger
   trigger:
     id: openURL
@@ -1041,7 +1041,7 @@
     ,\"{a50d61ca-d27b-437a-8b52-5fd801a0a88b}\"] intersect addonsInfo.addons|keys)|length\
     \ == 0 &&\n      ([\"www.facebook.com\",\"facebook.com\",\"messenger.com\",\"www.messenger.com\",\
     \"instagram.com\",\"www.instagram.com\",\"whatsapp.com\",\"www.whatsapp.com\",\"web.whatsapp.com\"]\
-    intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && firefoxVersion < 82 && userPrefs.cfrAddons"
+    intersect topFrecentSites[.frecency >= 5000]|mapToProperty('host'))|length > 0 && firefoxVersion >= 72 && userPrefs.cfrAddons"
   template: cfr_doorhanger
   trigger:
     id: openURL


### PR DESCRIPTION
I've updated the icon paths to the ones that work for 82+ and updated the minimum firefoxVersion.