### PR TITLE
Reset the targeting channel to release

### DIFF
--- a/messaging-experiments-82.json
+++ b/messaging-experiments-82.json
@@ -324,7 +324,7 @@
   {
     "id": "WIZARD-LESS-PASSWORD-IMPORT-AUTOCOMPLETE-EXPERIMENT",
     "enabled": true,
-    "targeting": "firefoxVersion >= '82.' && browserSettings.update.channel != 'release' && localeLanguageCode == 'en' && 'app.shield.optoutstudies.enabled'|preferenceValue && (isFirstStartup || 'password-autocomplete-wizardless' in activeExperiments)",
+    "targeting": "firefoxVersion >= '82.' && browserSettings.update.channel == 'release' && localeLanguageCode == 'en' && 'app.shield.optoutstudies.enabled'|preferenceValue && (isFirstStartup || 'password-autocomplete-wizardless' in activeExperiments)",
     "arguments": {
       "slug": "password-autocomplete-wizardless",
       "startDate": null,
@@ -411,7 +411,7 @@
   {
     "id": "MULTI-STAGE-ABOUTWELCOME-ZERO-STAGE",
     "enabled": true,
-    "targeting": "firefoxVersion >= '82.' && (browserSettings.update.channel == 'release' || browserSettings.update.channel == 'beta') && localeLanguageCode == \"en\" && ((isFirstStartup && !('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue)) || 'bug-1668928-message-multi-stage-aboutwelcome-zero-stage-release-82-83' in activeExperiments) && 'app.shield.optoutstudies.enabled'|preferenceValue",
+    "targeting": "firefoxVersion >= '82.' && browserSettings.update.channel == 'release' && localeLanguageCode == \"en\" && ((isFirstStartup && !('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue)) || 'bug-1668928-message-multi-stage-aboutwelcome-zero-stage-release-82-83' in activeExperiments) && 'app.shield.optoutstudies.enabled'|preferenceValue",
     "arguments": {
       "slug": "bug-1668928-message-multi-stage-aboutwelcome-zero-stage-release-82-83",
       "startDate": null,

--- a/messaging-experiments-82.yaml
+++ b/messaging-experiments-82.yaml
@@ -237,7 +237,7 @@
 - id: WIZARD-LESS-PASSWORD-IMPORT-AUTOCOMPLETE-EXPERIMENT
   enabled: true
   targeting: firefoxVersion >= '82.' &&
-    browserSettings.update.channel != 'release' &&
+    browserSettings.update.channel == 'release' &&
     localeLanguageCode == 'en' &&
     'app.shield.optoutstudies.enabled'|preferenceValue &&
     (isFirstStartup ||
@@ -308,7 +308,7 @@
   enabled: true
   # The filter `!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue)` is used to exclude
   # users who have switched channels or re-installed the browser without having a new profile
-  targeting: firefoxVersion >= '82.' && (browserSettings.update.channel == 'release' || browserSettings.update.channel == 'beta') && localeLanguageCode == "en" && ((isFirstStartup && !('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue)) || 'bug-1668928-message-multi-stage-aboutwelcome-zero-stage-release-82-83' in activeExperiments) && 'app.shield.optoutstudies.enabled'|preferenceValue
+  targeting: firefoxVersion >= '82.' && browserSettings.update.channel == 'release' && localeLanguageCode == "en" && ((isFirstStartup && !('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue)) || 'bug-1668928-message-multi-stage-aboutwelcome-zero-stage-release-82-83' in activeExperiments) && 'app.shield.optoutstudies.enabled'|preferenceValue
   arguments:
     slug: bug-1668928-message-multi-stage-aboutwelcome-zero-stage-release-82-83
     startDate:


### PR DESCRIPTION
Update the release channel in the targeting for wizardless and zero-onboarding experiments.

re: @piatra, the recipe on RS stage is up-to-date for the homepage-search experiment, I will copy directly from there to prod with some minor tweaks on targeting. 