### PR TITLE
Bug 1684527 - The FxA Bookmark Panel CFR is displayed 3 times in one day

### DIFF
--- a/cfr-fxa.json
+++ b/cfr-fxa.json
@@ -1,6 +1,9 @@
 [
   {
     "id": "FXA_BOOKMARK_PANEL_71_plus",
+    "groups": [
+      "cfr"
+    ],
     "content": {
       "background_color_1": "#7d31ae",
       "background_color_2": "#5033be",

--- a/cfr-fxa.yaml
+++ b/cfr-fxa.yaml
@@ -1,4 +1,6 @@
 - id: FXA_BOOKMARK_PANEL_71_plus
+  groups:
+    - cfr
   content:
     background_color_1: '#7d31ae'
     background_color_2: '#5033be'

--- a/schema/cfr-fxa.schema.json
+++ b/schema/cfr-fxa.schema.json
@@ -19,6 +19,14 @@
       "type": "string",
       "description": "Message identifier"
     },
+    "groups": {
+      "description": "Array of preferences used to control `enabled` status of the group. If any is `false` the group is disabled.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Preference name"
+      }
+    },
     "content": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
This was missed when we added the `groups` field to all the CFR messages.