### PR TITLE
Bug 1684839 - Remove 'where' param for tab open configuration

### DIFF
--- a/whats-new-panel.json
+++ b/whats-new-panel.json
@@ -87,7 +87,6 @@
         "string_id": "cfr-whatsnew-search-shortcuts-body"
       },
       "cta_url": "https://support.mozilla.org/1/firefox/%VERSION%/%OS%/%LOCALE%/search-shortcuts",
-      "cta_where": "tab",
       "cta_type": "OPEN_URL",
       "link_text": {
         "string_id": "cfr-whatsnew-pip-cta"

--- a/whats-new-panel.yaml
+++ b/whats-new-panel.yaml
@@ -74,7 +74,6 @@
       string_id: cfr-whatsnew-search-shortcuts-body
     cta_url: https://support.mozilla.org/1/firefox/%VERSION%/%OS%/%LOCALE%/search-shortcuts
     # Open in a new tab and set focus to it
-    cta_where: tab
     cta_type: OPEN_URL
     link_text:
       string_id: cfr-whatsnew-pip-cta


### PR DESCRIPTION
Looks like the default is ok (the other messages work as expected). 