### PR TITLE
Bug 1689738 - Make Fission doorhanger Nightly-only

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -949,7 +949,7 @@
     "groups": [
       "cfr"
     ],
-    "targeting": "isFissionExperimentEnabled",
+    "targeting": "isFissionExperimentEnabled && browserSettings.update.channel in ['nightly', 'default']",
     "frequency": {
       "lifetime": 1
     },

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -645,7 +645,7 @@
 - id: FISSION_EXPERIMENT_CONFIRMATION
   groups:
     - cfr
-  targeting: "isFissionExperimentEnabled"
+  targeting: "isFissionExperimentEnabled && browserSettings.update.channel in ['nightly', 'default']"
   frequency:
     lifetime: 1
   template: cfr_doorhanger


### PR DESCRIPTION
Making this `default` too so it works for local builds.