### PR TITLE
Bug 1695320, 1697012 - Update primary button string and remove icon for DOH message

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -463,7 +463,6 @@
       "text": {
         "string_id": "cfr-doorhanger-doh-body"
       },
-      "icon": "chrome://browser/skin/connection-secure.svg",
       "buttons": {
         "secondary": [
           {
@@ -477,7 +476,7 @@
         ],
         "primary": {
           "label": {
-            "string_id": "cfr-doorhanger-doh-primary-button"
+            "string_id": "cfr-doorhanger-doh-primary-button-2"
           },
           "action": {
             "type": "ACCEPT_DOH"

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -303,7 +303,6 @@
     layout: icon_and_message
     text:
       string_id: cfr-doorhanger-doh-body
-    icon: chrome://browser/skin/connection-secure.svg
     buttons:
       secondary:
         - label:
@@ -312,7 +311,7 @@
             type: DISABLE_DOH
       primary:
         label:
-          string_id: cfr-doorhanger-doh-primary-button
+          string_id: cfr-doorhanger-doh-primary-button-2
         action:
           type: ACCEPT_DOH
     bucket_id: DOH_ROLLOUT_CONFIRMATION


### PR DESCRIPTION
2 in 1 update for the DOH message. Waiting on the string change to land in Nightly first before pushing to RS.