### PR TITLE
Create a separate 89+ DOH message

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -449,11 +449,11 @@
     }
   },
   {
-    "id": "DOH_ROLLOUT_CONFIRMATION",
+    "id": "DOH_ROLLOUT_CONFIRMATION_89",
     "groups": [
       "cfr"
     ],
-    "targeting": "'doh-rollout.enabled'|preferenceValue && !'doh-rollout.disable-heuristics'|preferenceValue && !'doh-rollout.skipHeuristicsCheck'|preferenceValue && !'doh-rollout.doorhanger-decision'|preferenceValue && firefoxVersion >= 79",
+    "targeting": "'doh-rollout.enabled'|preferenceValue && !'doh-rollout.disable-heuristics'|preferenceValue && !'doh-rollout.skipHeuristicsCheck'|preferenceValue && !'doh-rollout.doorhanger-decision'|preferenceValue && firefoxVersion >= 89",
     "template": "cfr_doorhanger",
     "content": {
       "skip_address_bar_notifier": true,
@@ -483,7 +483,7 @@
           }
         }
       },
-      "bucket_id": "DOH_ROLLOUT_CONFIRMATION",
+      "bucket_id": "DOH_ROLLOUT_CONFIRMATION_89",
       "heading_text": {
         "string_id": "cfr-doorhanger-doh-header"
       },

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -291,10 +291,10 @@
   template: cfr_doorhanger
   trigger:
     id: newSavedLogin
-- id: DOH_ROLLOUT_CONFIRMATION
+- id: DOH_ROLLOUT_CONFIRMATION_89
   groups:
     - cfr
-  targeting: "'doh-rollout.enabled'|preferenceValue && !'doh-rollout.disable-heuristics'|preferenceValue && !'doh-rollout.skipHeuristicsCheck'|preferenceValue && !'doh-rollout.doorhanger-decision'|preferenceValue && firefoxVersion >= 79"
+  targeting: "'doh-rollout.enabled'|preferenceValue && !'doh-rollout.disable-heuristics'|preferenceValue && !'doh-rollout.skipHeuristicsCheck'|preferenceValue && !'doh-rollout.doorhanger-decision'|preferenceValue && firefoxVersion >= 89"
   template: cfr_doorhanger
   content:
     skip_address_bar_notifier: true
@@ -314,7 +314,7 @@
           string_id: cfr-doorhanger-doh-primary-button-2
         action:
           type: ACCEPT_DOH
-    bucket_id: DOH_ROLLOUT_CONFIRMATION
+    bucket_id: DOH_ROLLOUT_CONFIRMATION_89
     heading_text:
       string_id: cfr-doorhanger-doh-header
     info_icon:


### PR DESCRIPTION
I think it is easier to manage if we have a separate 89+ message, this way old clients keep the old string & icon for now and get the updated message in 89. It also makes it easier to publish the changes now and be done with it and we don't have to worry about translations being ready.