### PR TITLE
Update Infobar message for Firefox 90

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -197,6 +197,6 @@
         }
       ]
     },
-    "targeting": "(firefoxVersion >= 87 || (firefoxVersion >= 90 && source == 'startup')) && !isDefaultBrowser && !'browser.shell.checkDefaultBrowser'|preferenceValue && isMajorUpgrade != true && platformName != 'linux' && ((currentDate|date - profileAgeCreated) / 604800000) >= 5 && !activeNotifications"
+    "targeting": "((firefoxVersion >= 87 && firefoxVersion < 90) || (firefoxVersion >= 90 && source == 'startup')) && !isDefaultBrowser && !'browser.shell.checkDefaultBrowser'|preferenceValue && isMajorUpgrade != true && platformName != 'linux' && ((currentDate|date - profileAgeCreated) / 604800000) >= 5 && !activeNotifications"
   }
 ]

--- a/cfr.json
+++ b/cfr.json
@@ -197,6 +197,6 @@
         }
       ]
     },
-    "targeting": "firefoxVersion >= 87 && !isDefaultBrowser && !'browser.shell.checkDefaultBrowser'|preferenceValue && isMajorUpgrade != true && platformName != 'linux' && ((currentDate|date - profileAgeCreated) / 604800000) >= 5 && !activeNotifications"
+    "targeting": "(firefoxVersion >= 87 || (firefoxVersion >= 90 && source == 'startup')) && !isDefaultBrowser && !'browser.shell.checkDefaultBrowser'|preferenceValue && isMajorUpgrade != true && platformName != 'linux' && ((currentDate|date - profileAgeCreated) / 604800000) >= 5 && !activeNotifications"
   }
 ]

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -130,4 +130,4 @@
         cap: 1
   # Not default browser and user dismissed the default browser prompt
   targeting:
-    "firefoxVersion >= 87 && !isDefaultBrowser && !'browser.shell.checkDefaultBrowser'|preferenceValue && isMajorUpgrade != true && platformName != 'linux' && ((currentDate|date - profileAgeCreated) / 604800000) >= 5 && !activeNotifications"
+    "(firefoxVersion >= 87 || (firefoxVersion >= 90 && source == 'startup')) && !isDefaultBrowser && !'browser.shell.checkDefaultBrowser'|preferenceValue && isMajorUpgrade != true && platformName != 'linux' && ((currentDate|date - profileAgeCreated) / 604800000) >= 5 && !activeNotifications"

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -129,5 +129,8 @@
       - period: 3024000000  # 86400000 * 35 (35 days to ms)
         cap: 1
   # Not default browser and user dismissed the default browser prompt
+  # For Firefox version 87-89 the message is triggered only on the newtab page.
+  # For versions 90+ we trigger the message at startup and want to ignore the
+  # newtab trigger.
   targeting:
-    "(firefoxVersion >= 87 || (firefoxVersion >= 90 && source == 'startup')) && !isDefaultBrowser && !'browser.shell.checkDefaultBrowser'|preferenceValue && isMajorUpgrade != true && platformName != 'linux' && ((currentDate|date - profileAgeCreated) / 604800000) >= 5 && !activeNotifications"
+    "((firefoxVersion >= 87 && firefoxVersion < 90) || (firefoxVersion >= 90 && source == 'startup')) && !isDefaultBrowser && !'browser.shell.checkDefaultBrowser'|preferenceValue && isMajorUpgrade != true && platformName != 'linux' && ((currentDate|date - profileAgeCreated) / 604800000) >= 5 && !activeNotifications"


### PR DESCRIPTION
In bug 1681130 we updated the trigger for `defaultBrowserCheck` (that shows the infobar message) and it can be sent twice now also at `startup` (in addition to `newtab` events that we already had covered).
Now in 90 at browser startup two events happen:
* 1 trigger from the `startup` event
* 1 trigger from the pre-loading of the newtab page that happens in the background
And this race creates a situation where a message is shown twice.
The update to the targeting condition is
```
(firefoxVersion >= 87 || (firefoxVersion >= 90 && source == 'startup'))
```
So for Firefox 90 we only listen for the `startup` source and ignore the other `newtab` source.