### PR TITLE
Continue Nimbus ECO rollout using cfr

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -282,5 +282,93 @@
         "facebook.com"
       ]
     }
+  },
+  {
+    "id": "better-internet-c-rollout-cfr",
+    "groups": [
+      "eco"
+    ],
+    "content": {
+      "template": "logo-and-content",
+      "logoImageURL": "https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg",
+      "logo": {
+        "imageURL": "https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg",
+        "size": "115px"
+      },
+      "body": {
+        "title": {
+          "label": "A better Internet starts with you",
+          "size": "24px"
+        },
+        "text": {
+          "label": "When you use Firefox, you\u2019re voting for an open and accessible Internet that\u2019s better for everyone.",
+          "size": "16px"
+        },
+        "primary": {
+          "label": "Pin to taskbar",
+          "action": {
+            "type": "PIN_FIREFOX_TO_TASKBAR"
+          }
+        },
+        "secondary": {
+          "label": "Not now",
+          "action": {
+            "type": "CANCEL"
+          }
+        }
+      }
+    },
+    "trigger": {
+      "id": "defaultBrowserCheck"
+    },
+    "template": "spotlight",
+    "frequency": {
+      "lifetime": 1
+    },
+    "targeting": "userMonthlyActivity|length >= 1 && userMonthlyActivity|length <= 6 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && version|versionCompare('94.!') >= 0 && locale in ['en-CA', 'en-GB', 'en-US'] && source == 'startup' && !isMajorUpgrade && !activeNotifications && (messageImpressions|keys intersect [ 'better-internet-c-rollout:rollout-30', 'better-internet-infrequent-eco2202:control', 'better-internet-infrequent-eco2202:treatment-a', 'better-internet-infrequent-eco2202:treatment-b', 'better-internet-infrequent-modal:treatment-a', 'better-internet-infrequent-modal:treatment-b', 'better-internet-infrequent-modal:treatment-c', 'download-mobile-regular-modal:treatment-a', 'download-mobile-regular-modal:treatment-b', 'download-mobile-regular-modal:treatment-c', 'peace-of-mind-a-rollout:rollout-30', 'peace-of-mind-casual-modal:treatment-a', 'peace-of-mind-casual-modal:treatment-b', 'peace-of-mind-casual-modal:treatment-c' ])|length == 0"
+  },
+  {
+    "id": "peace-of-mind-a-rollout-cfr",
+    "groups": [
+      "eco"
+    ],
+    "content": {
+      "template": "logo-and-content",
+      "logoImageURL": "https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png",
+      "logo": {
+        "imageURL": "https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png",
+        "size": "115px"
+      },
+      "body": {
+        "title": {
+          "label": "We\u2019ve got you covered",
+          "size": "24px"
+        },
+        "text": {
+          "label": "Every month, Firefox blocks an average of over 3,000 trackers per user. Because nothing, especially privacy nuisances like trackers, should stand between you and the good Internet.",
+          "size": "16px"
+        },
+        "primary": {
+          "label": "Pin to taskbar",
+          "action": {
+            "type": "PIN_FIREFOX_TO_TASKBAR"
+          }
+        },
+        "secondary": {
+          "label": "Not now",
+          "action": {
+            "type": "CANCEL"
+          }
+        }
+      }
+    },
+    "trigger": {
+      "id": "defaultBrowserCheck"
+    },
+    "template": "spotlight",
+    "frequency": {
+      "lifetime": 1
+    },
+    "targeting": "userMonthlyActivity|length >= 7 && userMonthlyActivity|length <= 13 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && version|versionCompare('94.!') >= 0 && locale in ['en-CA', 'en-GB', 'en-US'] && source == 'startup' && !isMajorUpgrade && !activeNotifications && (messageImpressions|keys intersect [ 'better-internet-c-rollout:rollout-30', 'better-internet-infrequent-eco2202:control', 'better-internet-infrequent-eco2202:treatment-a', 'better-internet-infrequent-eco2202:treatment-b', 'better-internet-infrequent-modal:treatment-a', 'better-internet-infrequent-modal:treatment-b', 'better-internet-infrequent-modal:treatment-c', 'download-mobile-regular-modal:treatment-a', 'download-mobile-regular-modal:treatment-b', 'download-mobile-regular-modal:treatment-c', 'peace-of-mind-a-rollout:rollout-30', 'peace-of-mind-casual-modal:treatment-a', 'peace-of-mind-casual-modal:treatment-b', 'peace-of-mind-casual-modal:treatment-c' ])|length == 0"
   }
 ]

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -197,3 +197,125 @@
       - sling.com
       - www.facebook.com
       - facebook.com
+- id: better-internet-c-rollout-cfr
+  groups:
+    - eco
+  content:
+    template: logo-and-content
+    logoImageURL: https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg
+    logo:
+      imageURL: https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg
+      size: 115px
+    body:
+      title:
+        label: A better Internet starts with you
+        size: 24px
+      text:
+        label: When you use Firefox, you’re voting for an open and accessible Internet that’s better for everyone.
+        size: 16px
+      primary:
+        label: Pin to taskbar
+        action:
+          type: PIN_FIREFOX_TO_TASKBAR
+      secondary:
+        label: Not now
+        action:
+          type: CANCEL
+  trigger:
+    id: defaultBrowserCheck
+  template: spotlight
+  frequency:
+    lifetime: 1
+  # 1. Nimbus rollout enrollment targeting except sticky and study opt-out
+  # 2. Nimbus rollout message targeting except user prefs (handled by groups)
+  # 3. Additional message non-overlap
+  targeting: >-
+    userMonthlyActivity|length >= 1 &&
+    userMonthlyActivity|length <= 6 &&
+    (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 &&
+    doesAppNeedPin  &&
+    browserSettings.update.channel == 'release' &&
+    version|versionCompare('94.!') >= 0 &&
+    locale in ['en-CA', 'en-GB', 'en-US']
+    &&
+    source == 'startup' &&
+    !isMajorUpgrade &&
+    !activeNotifications
+    &&
+    (messageImpressions|keys intersect [
+    'better-internet-c-rollout:rollout-30',
+    'better-internet-infrequent-eco2202:control',
+    'better-internet-infrequent-eco2202:treatment-a',
+    'better-internet-infrequent-eco2202:treatment-b',
+    'better-internet-infrequent-modal:treatment-a',
+    'better-internet-infrequent-modal:treatment-b',
+    'better-internet-infrequent-modal:treatment-c',
+    'download-mobile-regular-modal:treatment-a',
+    'download-mobile-regular-modal:treatment-b',
+    'download-mobile-regular-modal:treatment-c',
+    'peace-of-mind-a-rollout:rollout-30',
+    'peace-of-mind-casual-modal:treatment-a',
+    'peace-of-mind-casual-modal:treatment-b',
+    'peace-of-mind-casual-modal:treatment-c'
+    ])|length == 0
+- id: peace-of-mind-a-rollout-cfr
+  groups:
+    - eco
+  content:
+    template: logo-and-content
+    logoImageURL: https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png
+    logo:
+      imageURL: https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png
+      size: 115px
+    body:
+      title:
+        label: We’ve got you covered
+        size: 24px
+      text:
+        label: Every month, Firefox blocks an average of over 3,000 trackers per user. Because nothing, especially privacy nuisances like trackers, should stand between you and the good Internet.
+        size: 16px
+      primary:
+        label: Pin to taskbar
+        action:
+          type: PIN_FIREFOX_TO_TASKBAR
+      secondary:
+        label: Not now
+        action:
+          type: CANCEL
+  trigger:
+    id: defaultBrowserCheck
+  template: spotlight
+  frequency:
+    lifetime: 1
+  # 1. Nimbus rollout enrollment targeting except sticky and study opt-out
+  # 2. Nimbus rollout message targeting except user prefs (handled by groups)
+  # 3. Additional message non-overlap
+  targeting: >-
+    userMonthlyActivity|length >= 7 &&
+    userMonthlyActivity|length <= 13 &&
+    (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 &&
+    doesAppNeedPin  &&
+    browserSettings.update.channel == 'release' &&
+    version|versionCompare('94.!') >= 0 &&
+    locale in ['en-CA', 'en-GB', 'en-US']
+    &&
+    source == 'startup' &&
+    !isMajorUpgrade &&
+    !activeNotifications
+    &&
+    (messageImpressions|keys intersect [
+    'better-internet-c-rollout:rollout-30',
+    'better-internet-infrequent-eco2202:control',
+    'better-internet-infrequent-eco2202:treatment-a',
+    'better-internet-infrequent-eco2202:treatment-b',
+    'better-internet-infrequent-modal:treatment-a',
+    'better-internet-infrequent-modal:treatment-b',
+    'better-internet-infrequent-modal:treatment-c',
+    'download-mobile-regular-modal:treatment-a',
+    'download-mobile-regular-modal:treatment-b',
+    'download-mobile-regular-modal:treatment-c',
+    'peace-of-mind-a-rollout:rollout-30',
+    'peace-of-mind-casual-modal:treatment-a',
+    'peace-of-mind-casual-modal:treatment-b',
+    'peace-of-mind-casual-modal:treatment-c'
+    ])|length == 0

--- a/message-groups.json
+++ b/message-groups.json
@@ -32,5 +32,21 @@
     "userPreferences": [
       "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features"
     ]
+  },
+  {
+    "id": "eco",
+    "enabled": true,
+    "type": "remote-settings",
+    "frequency": {
+      "custom": [
+        {
+          "period": 2419200000,
+          "cap": 1
+        }
+      ]
+    },
+    "userPreferences": [
+      "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features"
+    ]
   }
 ]

--- a/message-groups.yaml
+++ b/message-groups.yaml
@@ -3,15 +3,23 @@
   type: remote-settings
   frequency:
     custom:
-      - {period: 86400000, cap: 1}
+      - {period: 86400000, cap: 1}  # 1 day
 - id: cfr-experiments
   enabled: true
   type: remote-settings
   frequency:
     custom:
-      - {period: 86400000, cap: 1}
+      - {period: 86400000, cap: 1}  # 1 day
 - id: moments-pages
   enabled: true
   type: remote-settings
+  userPreferences:
+    - browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features
+- id: eco
+  enabled: true
+  type: remote-settings
+  frequency:
+    custom:
+      - {period: 2419200000, cap: 1}  # 4 weeks
   userPreferences:
     - browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features

--- a/schema/cfr.schema.json
+++ b/schema/cfr.schema.json
@@ -380,8 +380,7 @@
           ]
         }
       },
-      "additionalProperties": true,
-      "required": ["category", "bucket_id"]
+      "additionalProperties": true
     },
     "frequency": {
       "type": "object",

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -19,6 +19,7 @@ EVALUATOR.add_transform('mapToProperty', lambda x, y: [])
 EVALUATOR.add_transform('keys', lambda x: [])
 EVALUATOR.add_transform('bucketSample', lambda x, y, z, q: False)
 EVALUATOR.add_transform('stableSample', lambda x, y: False)
+EVALUATOR.add_transform('versionCompare', lambda x: 0)
 
 # cache all the known schemas to validate experiments
 ALL_SCHEMAS = dict()


### PR DESCRIPTION
Basically copy https://experimenter.services.mozilla.com/nimbus/better-internet-c-rollout/details and will also need to do https://experimenter.services.mozilla.com/nimbus/peace-of-mind-a-rollout/details

~I think I still need to add some bucket sampling to get 90% instead of 100%?~