### PR TITLE
Add ECO fast-pace global rollout

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -417,7 +417,7 @@
     "frequency": {
       "lifetime": 1
     },
-    "targeting": "userMonthlyActivity|length >= 1 && userMonthlyActivity|length <= 6 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && version|versionCompare('94.!') >= 0 && source == 'startup' && !isMajorUpgrade && !activeNotifications && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']"
+    "targeting": "userMonthlyActivity|length >= 1 && userMonthlyActivity|length <= 6 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']"
   },
   {
     "id": "peace-of-mind-a-rollout-fast",
@@ -469,6 +469,6 @@
     "frequency": {
       "lifetime": 1
     },
-    "targeting": "userMonthlyActivity|length >= 7 && userMonthlyActivity|length <= 13 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && version|versionCompare('94.!') >= 0 && source == 'startup' && !isMajorUpgrade && !activeNotifications && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']"
+    "targeting": "userMonthlyActivity|length >= 7 && userMonthlyActivity|length <= 13 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']"
   }
 ]

--- a/cfr.json
+++ b/cfr.json
@@ -417,7 +417,7 @@
     "frequency": {
       "lifetime": 1
     },
-    "targeting": "userMonthlyActivity|length >= 1 && userMonthlyActivity|length <= 6 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX']"
+    "targeting": "userMonthlyActivity|length >= 1 && userMonthlyActivity|length <= 6 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja', 'ja-JP-macos']"
   },
   {
     "id": "peace-of-mind-a-rollout-fast",
@@ -469,6 +469,6 @@
     "frequency": {
       "lifetime": 1
     },
-    "targeting": "userMonthlyActivity|length >= 7 && userMonthlyActivity|length <= 13 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX']"
+    "targeting": "userMonthlyActivity|length >= 7 && userMonthlyActivity|length <= 13 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja', 'ja-JP-macos']"
   }
 ]

--- a/cfr.json
+++ b/cfr.json
@@ -417,7 +417,7 @@
     "frequency": {
       "lifetime": 1
     },
-    "targeting": "userMonthlyActivity|length >= 1 && userMonthlyActivity|length <= 6 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']"
+    "targeting": "userMonthlyActivity|length >= 1 && userMonthlyActivity|length <= 6 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX']"
   },
   {
     "id": "peace-of-mind-a-rollout-fast",
@@ -469,6 +469,6 @@
     "frequency": {
       "lifetime": 1
     },
-    "targeting": "userMonthlyActivity|length >= 7 && userMonthlyActivity|length <= 13 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']"
+    "targeting": "userMonthlyActivity|length >= 7 && userMonthlyActivity|length <= 13 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX']"
   }
 ]

--- a/cfr.json
+++ b/cfr.json
@@ -366,5 +366,109 @@
       "lifetime": 1
     },
     "targeting": "userMonthlyActivity|length >= 7 && userMonthlyActivity|length <= 13 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && version|versionCompare('94.!') >= 0 && locale in ['en-CA', 'en-GB', 'en-US'] && source == 'startup' && !isMajorUpgrade && !activeNotifications && (messageImpressions|keys intersect [ 'better-internet-c-rollout:rollout-30', 'better-internet-infrequent-eco2202:control', 'better-internet-infrequent-eco2202:treatment-a', 'better-internet-infrequent-eco2202:treatment-b', 'better-internet-infrequent-modal:treatment-a', 'better-internet-infrequent-modal:treatment-b', 'better-internet-infrequent-modal:treatment-c', 'download-mobile-regular-modal:treatment-a', 'download-mobile-regular-modal:treatment-b', 'download-mobile-regular-modal:treatment-c', 'peace-of-mind-a-rollout:rollout-30', 'peace-of-mind-casual-modal:treatment-a', 'peace-of-mind-casual-modal:treatment-b', 'peace-of-mind-casual-modal:treatment-c' ])|length == 0"
+  },
+  {
+    "id": "better-internet-c-rollout-fast",
+    "groups": [
+      "eco"
+    ],
+    "content": {
+      "template": "logo-and-content",
+      "logoImageURL": "https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg",
+      "logo": {
+        "imageURL": "https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg",
+        "size": "115px"
+      },
+      "body": {
+        "title": {
+          "label": {
+            "string_id": "spotlight-better-internet-header"
+          },
+          "size": "24px"
+        },
+        "text": {
+          "label": {
+            "string_id": "spotlight-better-internet-body"
+          },
+          "size": "16px"
+        },
+        "primary": {
+          "label": {
+            "string_id": "spotlight-pin-primary-button"
+          },
+          "action": {
+            "type": "PIN_FIREFOX_TO_TASKBAR"
+          }
+        },
+        "secondary": {
+          "label": {
+            "string_id": "spotlight-pin-secondary-button"
+          },
+          "action": {
+            "type": "CANCEL"
+          }
+        }
+      }
+    },
+    "trigger": {
+      "id": "defaultBrowserCheck"
+    },
+    "template": "spotlight",
+    "frequency": {
+      "lifetime": 1
+    },
+    "targeting": "userMonthlyActivity|length >= 1 && userMonthlyActivity|length <= 6 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && version|versionCompare('94.!') >= 0 && source == 'startup' && !isMajorUpgrade && !activeNotifications && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']"
+  },
+  {
+    "id": "peace-of-mind-a-rollout-fast",
+    "groups": [
+      "eco"
+    ],
+    "content": {
+      "template": "logo-and-content",
+      "logoImageURL": "https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png",
+      "logo": {
+        "imageURL": "https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png",
+        "size": "115px"
+      },
+      "body": {
+        "title": {
+          "label": {
+            "string_id": "spotlight-peace-mind-header"
+          },
+          "size": "24px"
+        },
+        "text": {
+          "label": {
+            "string_id": "spotlight-peace-mind-body"
+          },
+          "size": "16px"
+        },
+        "primary": {
+          "label": {
+            "string_id": "spotlight-pin-primary-button"
+          },
+          "action": {
+            "type": "PIN_FIREFOX_TO_TASKBAR"
+          }
+        },
+        "secondary": {
+          "label": {
+            "string_id": "spotlight-pin-secondary-button"
+          },
+          "action": {
+            "type": "CANCEL"
+          }
+        }
+      }
+    },
+    "trigger": {
+      "id": "defaultBrowserCheck"
+    },
+    "template": "spotlight",
+    "frequency": {
+      "lifetime": 1
+    },
+    "targeting": "userMonthlyActivity|length >= 7 && userMonthlyActivity|length <= 13 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && version|versionCompare('94.!') >= 0 && source == 'startup' && !isMajorUpgrade && !activeNotifications && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']"
   }
 ]

--- a/cfr.json
+++ b/cfr.json
@@ -374,6 +374,7 @@
     ],
     "content": {
       "template": "logo-and-content",
+      "logoImageURL": "https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg",
       "logo": {
         "imageURL": "https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg",
         "size": "115px"
@@ -425,6 +426,7 @@
     ],
     "content": {
       "template": "logo-and-content",
+      "logoImageURL": "https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png",
       "logo": {
         "imageURL": "https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png",
         "size": "115px"

--- a/cfr.json
+++ b/cfr.json
@@ -417,7 +417,7 @@
     "frequency": {
       "lifetime": 1
     },
-    "targeting": "userMonthlyActivity|length >= 1 && userMonthlyActivity|length <= 6 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja', 'ja-JP-macos']"
+    "targeting": "userMonthlyActivity|length >= 1 && userMonthlyActivity|length <= 6 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja']"
   },
   {
     "id": "peace-of-mind-a-rollout-fast",
@@ -469,6 +469,6 @@
     "frequency": {
       "lifetime": 1
     },
-    "targeting": "userMonthlyActivity|length >= 7 && userMonthlyActivity|length <= 13 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja', 'ja-JP-macos']"
+    "targeting": "userMonthlyActivity|length >= 7 && userMonthlyActivity|length <= 13 && (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 && doesAppNeedPin  && browserSettings.update.channel == 'release' && source == 'startup' && !isMajorUpgrade && !activeNotifications && version|versionCompare('95.!') >= 0 && !(version in ['96.0', '96.0.1']) && locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja']"
   }
 ]

--- a/cfr.json
+++ b/cfr.json
@@ -374,7 +374,6 @@
     ],
     "content": {
       "template": "logo-and-content",
-      "logoImageURL": "https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg",
       "logo": {
         "imageURL": "https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg",
         "size": "115px"
@@ -426,7 +425,6 @@
     ],
     "content": {
       "template": "logo-and-content",
-      "logoImageURL": "https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png",
       "logo": {
         "imageURL": "https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png",
         "size": "115px"

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -359,21 +359,22 @@
   template: spotlight
   frequency:
     lifetime: 1
-  # 1. Nimbus rollout enrollment targeting except sticky, study opt-out, locales
+  # 1. Nimbus rollout enrollment targeting except sticky, study opt-out
   # 2. Nimbus rollout message targeting except user prefs (handled by groups)
-  # 3. Locales targeting
+  # 3. Custom version and locale targeting for RemoteL10n
   targeting: >-
     userMonthlyActivity|length >= 1 &&
     userMonthlyActivity|length <= 6 &&
     (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 &&
     doesAppNeedPin  &&
-    browserSettings.update.channel == 'release' &&
-    version|versionCompare('94.!') >= 0
+    browserSettings.update.channel == 'release'
     &&
     source == 'startup' &&
     !isMajorUpgrade &&
     !activeNotifications
     &&
+    version|versionCompare('95.!') >= 0 &&
+    !(version in ['96.0', '96.0.1']) &&
     locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']
 - id: peace-of-mind-a-rollout-fast
   groups:
@@ -408,19 +409,20 @@
   template: spotlight
   frequency:
     lifetime: 1
-  # 1. Nimbus rollout enrollment targeting except sticky, study opt-out, locales
+  # 1. Nimbus rollout enrollment targeting except sticky, study opt-out
   # 2. Nimbus rollout message targeting except user prefs (handled by groups)
-  # 3. Locales targeting
+  # 3. Custom version and locale targeting for RemoteL10n
   targeting: >-
     userMonthlyActivity|length >= 7 &&
     userMonthlyActivity|length <= 13 &&
     (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 &&
     doesAppNeedPin  &&
-    browserSettings.update.channel == 'release' &&
-    version|versionCompare('94.!') >= 0
+    browserSettings.update.channel == 'release'
     &&
     source == 'startup' &&
     !isMajorUpgrade &&
     !activeNotifications
     &&
+    version|versionCompare('95.!') >= 0 &&
+    !(version in ['96.0', '96.0.1']) &&
     locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -331,6 +331,7 @@
     - eco
   content:
     template: logo-and-content
+    logoImageURL: https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg
     logo:
       imageURL: https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg
       size: 115px
@@ -380,6 +381,7 @@
     - eco
   content:
     template: logo-and-content
+    logoImageURL: https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png
     logo:
       imageURL: https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png
       size: 115px

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -326,3 +326,101 @@
     'peace-of-mind-casual-modal:treatment-b',
     'peace-of-mind-casual-modal:treatment-c'
     ])|length == 0
+- id: better-internet-c-rollout-fast
+  groups:
+    - eco
+  content:
+    template: logo-and-content
+    logoImageURL: https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg
+    logo:
+      imageURL: https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg
+      size: 115px
+    body:
+      title:
+        label:
+          string_id: spotlight-better-internet-header
+        size: 24px
+      text:
+        label:
+          string_id: spotlight-better-internet-body
+        size: 16px
+      primary:
+        label:
+          string_id: spotlight-pin-primary-button
+        action:
+          type: PIN_FIREFOX_TO_TASKBAR
+      secondary:
+        label:
+          string_id: spotlight-pin-secondary-button
+        action:
+          type: CANCEL
+  trigger:
+    id: defaultBrowserCheck
+  template: spotlight
+  frequency:
+    lifetime: 1
+  # 1. Nimbus rollout enrollment targeting except sticky, study opt-out, locales
+  # 2. Nimbus rollout message targeting except user prefs (handled by groups)
+  # 3. Locales targeting
+  targeting: >-
+    userMonthlyActivity|length >= 1 &&
+    userMonthlyActivity|length <= 6 &&
+    (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 &&
+    doesAppNeedPin  &&
+    browserSettings.update.channel == 'release' &&
+    version|versionCompare('94.!') >= 0
+    &&
+    source == 'startup' &&
+    !isMajorUpgrade &&
+    !activeNotifications
+    &&
+    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']
+- id: peace-of-mind-a-rollout-fast
+  groups:
+    - eco
+  content:
+    template: logo-and-content
+    logoImageURL: https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png
+    logo:
+      imageURL: https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png
+      size: 115px
+    body:
+      title:
+        label:
+          string_id: spotlight-peace-mind-header
+        size: 24px
+      text:
+        label:
+          string_id: spotlight-peace-mind-body
+        size: 16px
+      primary:
+        label:
+          string_id: spotlight-pin-primary-button
+        action:
+          type: PIN_FIREFOX_TO_TASKBAR
+      secondary:
+        label:
+          string_id: spotlight-pin-secondary-button
+        action:
+          type: CANCEL
+  trigger:
+    id: defaultBrowserCheck
+  template: spotlight
+  frequency:
+    lifetime: 1
+  # 1. Nimbus rollout enrollment targeting except sticky, study opt-out, locales
+  # 2. Nimbus rollout message targeting except user prefs (handled by groups)
+  # 3. Locales targeting
+  targeting: >-
+    userMonthlyActivity|length >= 7 &&
+    userMonthlyActivity|length <= 13 &&
+    (currentDate|date - profileAgeCreated|date) / 86400000 >= 28 &&
+    doesAppNeedPin  &&
+    browserSettings.update.channel == 'release' &&
+    version|versionCompare('94.!') >= 0
+    &&
+    source == 'startup' &&
+    !isMajorUpgrade &&
+    !activeNotifications
+    &&
+    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -375,7 +375,7 @@
     &&
     version|versionCompare('95.!') >= 0 &&
     !(version in ['96.0', '96.0.1']) &&
-    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']
+    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX']
 - id: peace-of-mind-a-rollout-fast
   groups:
     - eco
@@ -425,4 +425,4 @@
     &&
     version|versionCompare('95.!') >= 0 &&
     !(version in ['96.0', '96.0.1']) &&
-    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'pl', 'it', 'es-MX', 'ja', 'ja-JP-mac']
+    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX']

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -375,7 +375,7 @@
     &&
     version|versionCompare('95.!') >= 0 &&
     !(version in ['96.0', '96.0.1']) &&
-    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja', 'ja-JP-macos']
+    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja']
 - id: peace-of-mind-a-rollout-fast
   groups:
     - eco
@@ -425,4 +425,4 @@
     &&
     version|versionCompare('95.!') >= 0 &&
     !(version in ['96.0', '96.0.1']) &&
-    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja', 'ja-JP-macos']
+    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja']

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -375,7 +375,7 @@
     &&
     version|versionCompare('95.!') >= 0 &&
     !(version in ['96.0', '96.0.1']) &&
-    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX']
+    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja', 'ja-JP-macos']
 - id: peace-of-mind-a-rollout-fast
   groups:
     - eco
@@ -425,4 +425,4 @@
     &&
     version|versionCompare('95.!') >= 0 &&
     !(version in ['96.0', '96.0.1']) &&
-    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX']
+    locale in ['zh-CN', 'de', 'fr', 'es-ES', 'ru', 'pt-BR', 'it', 'es-MX', 'ja', 'ja-JP-macos']

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -331,7 +331,6 @@
     - eco
   content:
     template: logo-and-content
-    logoImageURL: https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg
     logo:
       imageURL: https://www.mozilla.org/media/img/firefox/onboarding/mountain.bd39012cc5a9.svg
       size: 115px
@@ -381,7 +380,6 @@
     - eco
   content:
     template: logo-and-content
-    logoImageURL: https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png
     logo:
       imageURL: https://www.mozilla.org/media/img/firefox/onboarding/umbrella.041dbea876c4.png
       size: 115px


### PR DESCRIPTION
Like the better-internet-c-rollout-cfr and peace-of-mind-a-rollout-cfr targeting but without the message impression check (only affected en-*) and new locales. Use strings from remote localization.