### PR TITLE
Bug 1766997 - [Windows] Scrollbars are wrongly displayed inside the default "ECO" spotlights

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -295,7 +295,7 @@
           "label": {
             "string_id": "spotlight-better-internet-header"
           },
-          "size": "22px"
+          "size": "20px"
         },
         "text": {
           "label": {
@@ -346,7 +346,7 @@
           "label": {
             "string_id": "spotlight-peace-mind-header"
           },
-          "size": "22px"
+          "size": "20px"
         },
         "text": {
           "label": {

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -217,7 +217,7 @@
       title:
         label:
           string_id: spotlight-better-internet-header
-        size: 22px
+        size: 20px
       text:
         label:
           string_id: spotlight-better-internet-body
@@ -264,7 +264,7 @@
       title:
         label:
           string_id: spotlight-peace-mind-header
-        size: 22px
+        size: 20px
       text:
         label:
           string_id: spotlight-peace-mind-body


### PR DESCRIPTION
Decrease font size of the title to avoid scrollbars in more locales. r? @punamdahiya looks like 20px happens to work for me on Windows 10 en-US, de, fr, ru, pl, es-ES, pt-BR, it, zh-CN.

I'll put the message on stage (preview) for QA to try out on more platforms/locales/configurations. QA verified 23px still had issues with `it`: https://bugzilla.mozilla.org/show_bug.cgi?id=1766997#c4