### PR TITLE
Bug 1740064 - Pause TCP rollout for end of Phase 1

### DIFF
--- a/cfr.json
+++ b/cfr.json
@@ -445,6 +445,6 @@
         }
       ]
     },
-    "targeting": "source == 'startup' && !isMajorUpgrade && 'app.shield.optoutstudies.enabled'|preferenceValue && browserSettings.update.channel in ['release', 'beta', 'aurora'] && version|versionCompare('100.0.1') >= 0 && 'network.cookie.cookieBehavior'|preferenceValue == 4 && !'privacy.restrict3rdpartystorage.rollout.enabledByDefault'|preferenceIsUserSet && !'browser.privatebrowsing.autostart'|preferenceValue && !'browser.search.param.google_channel_us'|preferenceValue('')|regExpMatch('^[ntc]us5$') && !'browser.search.param.google_channel_row'|preferenceValue('')|regExpMatch('^[ntc]row5$') && currentDate|date - profileAgeCreated >= 10800000"
+    "targeting": "false"
   }
 ]

--- a/cfr.yaml
+++ b/cfr.yaml
@@ -342,20 +342,4 @@
     custom:
       - period: 691200000  # 1000 * 60 * 60 * 24 * 8 (8 days in ms)
         cap: 1
-  # 1. Basic "study" message release/beta/aurora Fx100.0.1+ targeting
-  # 2. Custom TCP opt-in, e.g., default cookie behavior, not interacted, not experiment
-  # 3. Not new profiles at least 3 hours old in ms (1000 * 60 * 60 * 3)
-  targeting: >-
-    source == 'startup' &&
-    !isMajorUpgrade &&
-    'app.shield.optoutstudies.enabled'|preferenceValue &&
-    browserSettings.update.channel in ['release', 'beta', 'aurora'] &&
-    version|versionCompare('100.0.1') >= 0
-    &&
-    'network.cookie.cookieBehavior'|preferenceValue == 4 &&
-    !'privacy.restrict3rdpartystorage.rollout.enabledByDefault'|preferenceIsUserSet &&
-    !'browser.privatebrowsing.autostart'|preferenceValue &&
-    !'browser.search.param.google_channel_us'|preferenceValue('')|regExpMatch('^[ntc]us5$') &&
-    !'browser.search.param.google_channel_row'|preferenceValue('')|regExpMatch('^[ntc]row5$')
-    &&
-    currentDate|date - profileAgeCreated >= 10800000
+  targeting: "false"


### PR DESCRIPTION
Pause instead of archiving to allow unpausing while keeping impressions for frequency cap.